### PR TITLE
Add test SVG and background option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 
 - **2025-07-01** – M0 complete. Initialized Vite + React + R3F project with a placeholder `<CanvasStage />`. Lint and build pass.
 - **2025-07-02** – Added `ForegroundLayer` with SVG loading and demo in `CanvasStage`. Lint and build pass.
+- **2025-07-02** – Added diamond test SVG and background image support via URL params. Lint and build pass.
 
 ## Next Steps
-- Begin planning M2 (`useDragAndSpring`) once SVG support is confirmed.
-- Document usage of `ForegroundLayer` and create placeholder tests.
+- Verify background image configuration works across browsers.
+- Begin planning M2 (`useDragAndSpring`).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,19 @@
 import CanvasStage from './components/CanvasStage'
 import './App.css'
+import defaultBgUrl from './assets/wildflowers.png'
+
+function useBackgroundUrl(): string {
+  const params = new URLSearchParams(window.location.search)
+  return params.get('bg') || defaultBgUrl
+}
 
 export default function App() {
+  const bgUrl = useBackgroundUrl()
   return (
-    <div className="w-screen h-screen overflow-hidden">
+    <div
+      className="w-screen h-screen overflow-hidden bg-cover bg-center"
+      style={{ backgroundImage: `url(${bgUrl})` }}
+    >
       <CanvasStage />
     </div>
   )

--- a/src/assets/diamond.svg
+++ b/src/assets/diamond.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <polygon points="32,0 64,32 32,64 0,32" fill="black"/>
+</svg>

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -1,6 +1,12 @@
 import ForegroundLayer from './ForegroundLayer'
-import reactLogoUrl from '../assets/react.svg?url'
+import defaultSvgUrl from '../assets/diamond.svg?url'
+
+function useSvgUrl(): string {
+  const params = new URLSearchParams(window.location.search)
+  return params.get('svg') || defaultSvgUrl
+}
 
 export default function ForegroundLayerDemo() {
-  return <ForegroundLayer url={reactLogoUrl} />
+  const svgUrl = useSvgUrl()
+  return <ForegroundLayer url={svgUrl} color="#000000" />
 }


### PR DESCRIPTION
## Summary
- add a basic diamond SVG asset for testing
- allow overriding ForegroundLayer SVG via `svg` url param
- render CanvasStage over configurable image background via `bg` url param

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686443e05c0883329c308cb51694d704