### PR TITLE
Add SvgSize for configurable input layer scaling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **2025-07-01** – M0 complete. Initialized Vite + React + R3F project with a placeholder `<CanvasStage />`. Lint and build pass.
 - **2025-07-02** – Added `ForegroundLayer` with SVG loading and demo in `CanvasStage`. Lint and build pass.
 - **2025-07-02** – Added diamond test SVG and background image support via URL params. Lint and build pass.
+- **2025-07-03** – Added `SvgSize` and configurable sizing modes for `ForegroundLayer`. Lint and build pass.
 
 ## Next Steps
 - Verify background image configuration works across browsers.
-- Begin planning M2 (`useDragAndSpring`).
+- Begin M2 (`useDragAndSpring`) implementation.

--- a/src/components/ForegroundLayer.tsx
+++ b/src/components/ForegroundLayer.tsx
@@ -1,21 +1,49 @@
-import { useLoader } from '@react-three/fiber'
+import { useLoader, useThree } from '@react-three/fiber'
 import { SVGLoader } from 'three-stdlib'
 import { useMemo } from 'react'
 import * as THREE from 'three'
+import type { SvgSize } from '../types/svg'
 
 type Props = {
   url: string
   color?: string
+  size?: SvgSize
 }
 
-export default function ForegroundLayer({ url, color = '#ffffff' }: Props) {
+export default function ForegroundLayer({ url, color = '#ffffff', size = { type: 'scaled', factor: 0.01 } }: Props) {
+  const { viewport } = useThree()
   const { paths } = useLoader(SVGLoader, url)
   const shapes = useMemo(() => paths.flatMap((p) => p.toShapes(true)), [paths])
+  const geometries = useMemo(() => shapes.map((shape) => new THREE.ShapeGeometry(shape)), [shapes])
+  const bounds = useMemo(() => {
+    const box = new THREE.Box3()
+    geometries.forEach((g) => {
+      g.computeBoundingBox()
+      if (g.boundingBox) box.union(g.boundingBox)
+    })
+    return box
+  }, [geometries])
+
+  const nativeWidth = bounds.max.x - bounds.min.x
+  const nativeHeight = bounds.max.y - bounds.min.y
+  const scale = useMemo(() => {
+    switch (size.type) {
+      case 'natural':
+        return 1
+      case 'scaled':
+        return size.factor
+      case 'relative': {
+        const base = Math.min(viewport.width, viewport.height)
+        const largest = Math.max(nativeWidth, nativeHeight)
+        return (size.fraction * base) / largest
+      }
+    }
+  }, [size, viewport.width, viewport.height, nativeWidth, nativeHeight])
 
   return (
-    <group scale={0.01} position-z={0.1}>
-      {shapes.map((shape, idx) => (
-        <mesh key={idx} geometry={new THREE.ShapeGeometry(shape)}>
+    <group scale={scale} position-z={0.1}>
+      {geometries.map((geometry, idx) => (
+        <mesh key={idx} geometry={geometry}>
           <meshBasicMaterial color={color} toneMapped={false} />
         </mesh>
       ))}

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -8,5 +8,11 @@ function useSvgUrl(): string {
 
 export default function ForegroundLayerDemo() {
   const svgUrl = useSvgUrl()
-  return <ForegroundLayer url={svgUrl} color="#000000" />
+  return (
+    <ForegroundLayer
+      url={svgUrl}
+      color="#000000"
+      size={{ type: 'scaled', factor: 0.01 }}
+    />
+  )
 }

--- a/src/types/svg.ts
+++ b/src/types/svg.ts
@@ -1,0 +1,4 @@
+export type SvgSize =
+  | { type: 'natural' }
+  | { type: 'scaled'; factor: number }
+  | { type: 'relative'; fraction: number }


### PR DESCRIPTION
## Summary
- add `SvgSize` type for sizing configuration
- support natural, scaled, and relative sizes in `ForegroundLayer`
- pass a default scaled value in the demo
- document progress in `AGENTS.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686446f61c1c833296345aa59e6273b3