### PR TITLE
Implement feedback FBO core (M3 start)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,5 +23,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 
 - **2025-07-04** – Added cursor state management to `useDragAndSpring` so the canvas shows a grab hand when hovering/dragging. Lint and build pass.
 
+- **2025-07-05** – Started M3: added `useFeedbackFBO` hook, `motionBlur.frag` shader, and `FeedbackPlane` component. Wired into `ForegroundLayerDemo`. Lint and build pass.
+
 ## Next Steps
-- Begin M3 by creating the feedback FBO core and linking drag snapshots.
+- Connect `useFeedbackFBO` snapshot logic to drag/spring activity so trails only appear during motion.

--- a/src/components/FeedbackPlane.tsx
+++ b/src/components/FeedbackPlane.tsx
@@ -1,0 +1,18 @@
+import { useThree } from '@react-three/fiber'
+import * as THREE from 'three'
+
+type Props = { texture: THREE.Texture }
+
+export default function FeedbackPlane({ texture }: Props) {
+  const { viewport } = useThree()
+  return (
+    <mesh scale={[viewport.width, viewport.height, 1]} position-z={0}>
+      <planeGeometry args={[1, 1]} />
+      <meshBasicMaterial
+        map={texture}
+        transparent
+        toneMapped={false}
+      />
+    </mesh>
+  )
+}

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -1,6 +1,9 @@
 import ForegroundLayer from './ForegroundLayer'
 import defaultSvgUrl from '../assets/diamond.svg?url'
 import useDragAndSpring from '../hooks/useDragAndSpring'
+import useFeedbackFBO from '../hooks/useFeedbackFBO'
+import FeedbackPlane from './FeedbackPlane'
+import motionBlurFrag from '../shaders/motionBlur.frag'
 import { a } from '@react-spring/three'
 
 function useSvgUrl(): string {
@@ -11,13 +14,17 @@ function useSvgUrl(): string {
 export default function ForegroundLayerDemo() {
   const svgUrl = useSvgUrl()
   const { bind, pose } = useDragAndSpring()
+  const { snapshotRef, texture } = useFeedbackFBO(motionBlurFrag)
   return (
-    <a.group position-x={pose.x} position-y={pose.y} {...bind}>
-      <ForegroundLayer
-        url={svgUrl}
-        color="#000000"
-        size={{ type: 'scaled', factor: 0.01 }}
-      />
-    </a.group>
+    <>
+      <FeedbackPlane texture={texture} />
+      <a.group ref={snapshotRef} position-x={pose.x} position-y={pose.y} {...bind}>
+        <ForegroundLayer
+          url={svgUrl}
+          color="#000000"
+          size={{ type: 'scaled', factor: 0.01 }}
+        />
+      </a.group>
+    </>
   )
 }

--- a/src/glsl.d.ts
+++ b/src/glsl.d.ts
@@ -1,0 +1,8 @@
+declare module '*.frag' {
+  const content: string
+  export default content
+}
+declare module '*.vert' {
+  const content: string
+  export default content
+}

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -1,0 +1,96 @@
+import { useFrame, useThree } from '@react-three/fiber'
+import { useEffect, useMemo, useRef } from 'react'
+import * as THREE from 'three'
+
+const vertexShader = `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = vec4(position, 1.0);
+  }
+`
+
+export default function useFeedbackFBO(fragmentShader: string, decay = 0.9) {
+  const { gl, size, camera } = useThree()
+
+  const snapshotGroup = useRef(new THREE.Group())
+  const snapshotScene = useMemo(() => {
+    const s = new THREE.Scene()
+    s.add(snapshotGroup.current)
+    return s
+  }, [])
+
+  const readRT = useRef(new THREE.WebGLRenderTarget(size.width, size.height))
+  const writeRT = useRef(new THREE.WebGLRenderTarget(size.width, size.height))
+  const snapshotRT = useRef(new THREE.WebGLRenderTarget(size.width, size.height))
+
+  const uniforms = useMemo(
+    () => ({
+      uPrevFrame: { value: readRT.current.texture },
+      uSnapshot: { value: snapshotRT.current.texture },
+      uDecay: { value: decay },
+    }),
+    [decay]
+  )
+
+  const quadScene = useMemo(() => {
+    const scene = new THREE.Scene()
+    const material = new THREE.ShaderMaterial({
+      vertexShader,
+      fragmentShader,
+      uniforms,
+      transparent: true,
+    })
+    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), material)
+    scene.add(mesh)
+    return scene
+  }, [fragmentShader, uniforms])
+
+  const orthoCam = useMemo(
+    () => new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1),
+    []
+  )
+
+  useEffect(() => {
+    readRT.current.setSize(size.width, size.height)
+    writeRT.current.setSize(size.width, size.height)
+    snapshotRT.current.setSize(size.width, size.height)
+  }, [size])
+
+  useEffect(() => {
+    const read = readRT.current
+    const write = writeRT.current
+    const snap = snapshotRT.current
+    return () => {
+      read.dispose()
+      write.dispose()
+      snap.dispose()
+    }
+  }, [])
+
+  useFrame(() => {
+    // Snapshot pass
+    gl.setRenderTarget(snapshotRT.current)
+    gl.clear()
+    gl.render(snapshotScene, camera)
+
+    // Feedback pass
+    gl.setRenderTarget(writeRT.current)
+    gl.render(quadScene, orthoCam)
+    gl.setRenderTarget(null)
+
+    // Swap
+    const tmp = readRT.current
+    readRT.current = writeRT.current
+    writeRT.current = tmp
+    uniforms.uPrevFrame.value = readRT.current.texture
+
+    // Clear snapshot
+    gl.setRenderTarget(snapshotRT.current)
+    gl.setClearColor(0x000000, 0)
+    gl.clear(true, true, true)
+    gl.setRenderTarget(null)
+  })
+
+  return { snapshotRef: snapshotGroup, texture: readRT.current.texture }
+}

--- a/src/shaders/motionBlur.frag
+++ b/src/shaders/motionBlur.frag
@@ -1,0 +1,12 @@
+precision highp float;
+
+varying vec2 vUv;
+uniform sampler2D uPrevFrame;
+uniform sampler2D uSnapshot;
+uniform float uDecay;
+
+void main() {
+  vec4 history = texture2D(uPrevFrame, vUv);
+  vec4 snap = texture2D(uSnapshot, vUv);
+  gl_FragColor = history * uDecay + snap;
+}


### PR DESCRIPTION
## Summary
- start M3 with a motion-blur feedback buffer
- add `useFeedbackFBO` hook and `FeedbackPlane` component
- integrate feedback FBO into `ForegroundLayerDemo`
- log progress in `AGENTS.md`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68645047b3f88332ba7af09f84e06f49