### PR TITLE
Implement better random paint session logic

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 80
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **12** – Added tweakpane controls for shader selection and decay; introduced session-random uniform and new `randomPaint.frag` shader. Lint and build pass.
 - **13** – Modified `randomPaint.frag` to accumulate only alpha and ignore previous RGB history. Added ESLint ignores for Tweakpane usage. Lint passes with a warning; build succeeds despite a PostCSS warning.
 - **14** – Revised `randomPaint.frag` to preserve per-pixel color and fade history, enabling multi-color painting. Lint warns on hooks; build succeeds.
+- **15** – Added Prettier formatting, session-random reset on drag start, and fixed render blending so history color doesn't fade to black. Lint warns on hooks; build succeeds.
 
 ## Next Steps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.2.0",
         "postcss": "^8.5.6",
+        "prettier": "^3.6.2",
         "tailwindcss": "^4.1.11",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.35.0",
@@ -4363,6 +4364,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/promise-worker-transferable": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "@react-spring/shared": "^10.0.1",
@@ -32,6 +33,7 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.2.0",
     "postcss": "^8.5.6",
+    "prettier": "^3.6.2",
     "tailwindcss": "^4.1.11",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.0",

--- a/references/FragShaderProject.ts
+++ b/references/FragShaderProject.ts
@@ -4,43 +4,45 @@
  * like src/art/MyShader/MyShader.frag. See the docs for more info.
  */
 
-import * as THREE from 'three';
+import * as THREE from 'three'
 import Project, {
-    CanvasType,
-    type DetailWebGL2,
-    type ResizedDetailWebGL2,
-    type UpdateDetail
-} from './Project';
+  CanvasType,
+  type DetailWebGL2,
+  type ResizedDetailWebGL2,
+  type UpdateDetail,
+} from './Project'
 
 // Uniform names for non-params (i.e. uniforms not specific to a particular project)
 const uniformNames: Record<string, string> = {
-    time: 'time',
-    scaledTime: 'scaledTime',
-    renderSize: 'renderSize',
-    passBuffer: 'passBuffer'
-};
+  time: 'time',
+  scaledTime: 'scaledTime',
+  renderSize: 'renderSize',
+  passBuffer: 'passBuffer',
+}
 
 // Prefix used to define the pass number in the fragment shader (PASS_0, PASS_1, etc.)
-const PassDefPrefix = 'PASS_';
+const PassDefPrefix = 'PASS_'
 
 // Uniform typing stuff
-const supportedTypes = ['float', 'int', 'bool', 'vec2', 'vec3', 'vec4'] as const;
-type UniformType = (typeof supportedTypes)[number];
-type UniformParamType = number | number[] | boolean;
+const supportedTypes = ['float', 'int', 'bool', 'vec2', 'vec3', 'vec4'] as const
+type UniformType = (typeof supportedTypes)[number]
+type UniformParamType = number | number[] | boolean
 
 // Default values for supported uniform types
 const uniformParamDefaults: Record<UniformType, UniformParamType> = {
-    float: 0,
-    int: 0,
-    bool: false,
-    vec2: [0, 0],
-    vec3: [0, 0, 0],
-    vec4: [0, 0, 0, 0]
-};
+  float: 0,
+  int: 0,
+  bool: false,
+  vec2: [0, 0],
+  vec3: [0, 0, 0],
+  vec4: [0, 0, 0, 0],
+}
 
 // Type guard for supported uniform type strings
-function isSupportedUniformType(uniformTypeString: string): uniformTypeString is UniformType {
-    return supportedTypes.includes(uniformTypeString as UniformType);
+function isSupportedUniformType(
+  uniformTypeString: string
+): uniformTypeString is UniformType {
+  return supportedTypes.includes(uniformTypeString as UniformType)
 }
 
 // Passthrough vertex shader
@@ -51,256 +53,272 @@ const vertexShader = `
         vUv = uv;
         vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
         gl_Position = projectionMatrix * mvPosition;
-    }`;
+    }`
 
 type ScaledTimeUpdater = {
-    update: (time: number) => void;
-    reset: () => void;
-};
+  update: (time: number) => void
+  reset: () => void
+}
 
 export default class FragShaderProject extends Project {
-    canvasType = CanvasType.WebGL2;
+  canvasType = CanvasType.WebGL2
 
-    #renderer: THREE.WebGLRenderer | undefined;
-    #scene: THREE.Scene;
-    #camera: THREE.OrthographicCamera;
-    #quad: THREE.Mesh | null = null;
-    #renderTargets: THREE.WebGLRenderTarget[] = [];
-    #passMaterials: THREE.ShaderMaterial[] = [];
-    #finalPassMaterial: THREE.ShaderMaterial | null = null;
+  #renderer: THREE.WebGLRenderer | undefined
+  #scene: THREE.Scene
+  #camera: THREE.OrthographicCamera
+  #quad: THREE.Mesh | null = null
+  #renderTargets: THREE.WebGLRenderTarget[] = []
+  #passMaterials: THREE.ShaderMaterial[] = []
+  #finalPassMaterial: THREE.ShaderMaterial | null = null
 
-    #fragShader: string;
-    #uniforms: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        [uniform: string]: THREE.IUniform<any>;
-    } = {};
-    #nextAnimationFrame: number | null = null;
-    #scaledTimeUpdaters: ScaledTimeUpdater[] = [];
-    #paramUniformNames: string[] = [];
-    #lastRenderedTime = 0;
+  #fragShader: string
+  #uniforms: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [uniform: string]: THREE.IUniform<any>
+  } = {}
+  #nextAnimationFrame: number | null = null
+  #scaledTimeUpdaters: ScaledTimeUpdater[] = []
+  #paramUniformNames: string[] = []
+  #lastRenderedTime = 0
 
-    constructor(fragShader: string) {
-        super();
-        this.#fragShader = fragShader;
+  constructor(fragShader: string) {
+    super()
+    this.#fragShader = fragShader
 
-        // Initialize three stuff
-        this.#scene = new THREE.Scene();
-        this.#camera = new THREE.OrthographicCamera();
-        this.#camera.position.z = 1;
+    // Initialize three stuff
+    this.#scene = new THREE.Scene()
+    this.#camera = new THREE.OrthographicCamera()
+    this.#camera.position.z = 1
 
-        // Load the fragment shader and parse out the uniforms
-        const uniformLines = this.#fragShader.split(';').filter((line) => line.includes('uniform'));
-        uniformLines.forEach((line) => {
-            // Find uniform name and type for supported uniforms
-            const uniformLineComponents = line.split(/\s+/).filter((x) => x.trim().length > 0);
-            const uniformTypeIndex = uniformLineComponents.findIndex((x) =>
-                isSupportedUniformType(x)
-            );
-            if (!uniformTypeIndex) return;
-            const type = uniformLineComponents[uniformTypeIndex];
-            const name = uniformLineComponents[uniformTypeIndex + 1];
+    // Load the fragment shader and parse out the uniforms
+    const uniformLines = this.#fragShader
+      .split(';')
+      .filter((line) => line.includes('uniform'))
+    uniformLines.forEach((line) => {
+      // Find uniform name and type for supported uniforms
+      const uniformLineComponents = line
+        .split(/\s+/)
+        .filter((x) => x.trim().length > 0)
+      const uniformTypeIndex = uniformLineComponents.findIndex((x) =>
+        isSupportedUniformType(x)
+      )
+      if (!uniformTypeIndex) return
+      const type = uniformLineComponents[uniformTypeIndex]
+      const name = uniformLineComponents[uniformTypeIndex + 1]
 
-            // Provide scaled time uniforms if desired
-            const scaledTimeMatcher = new RegExp(`${uniformNames.scaledTime}\\d*`, 'i');
-            if (scaledTimeMatcher.test(name)) {
-                this.#scaledTimeUpdaters.push(this.#generateScaledTimeUpdater(name));
-                return;
-            }
+      // Provide scaled time uniforms if desired
+      const scaledTimeMatcher = new RegExp(
+        `${uniformNames.scaledTime}\\d*`,
+        'i'
+      )
+      if (scaledTimeMatcher.test(name)) {
+        this.#scaledTimeUpdaters.push(this.#generateScaledTimeUpdater(name))
+        return
+      }
 
-            // Ignore other non-user-defined uniforms
-            if (Object.keys(uniformNames).includes(name) || name.includes(uniformNames.passBuffer))
-                return;
+      // Ignore other non-user-defined uniforms
+      if (
+        Object.keys(uniformNames).includes(name) ||
+        name.includes(uniformNames.passBuffer)
+      )
+        return
 
-            // Use name and type to parameterize this uniform
-            if (isSupportedUniformType(type) && name.length > 0) {
-                // Create a default property value if the uniform type is supported
-                const value = uniformParamDefaults[type];
-                Object.defineProperty(this, name, {
-                    value,
-                    writable: true,
-                    enumerable: true,
-                    configurable: true
-                });
-                this.#uniforms[name] = { value: value };
-                this.#paramUniformNames.push(name);
-            }
-        });
+      // Use name and type to parameterize this uniform
+      if (isSupportedUniformType(type) && name.length > 0) {
+        // Create a default property value if the uniform type is supported
+        const value = uniformParamDefaults[type]
+        Object.defineProperty(this, name, {
+          value,
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        })
+        this.#uniforms[name] = { value: value }
+        this.#paramUniformNames.push(name)
+      }
+    })
+  }
+
+  init(detail: DetailWebGL2) {
+    if (!this.canvas) throw new Error('Canvas not initialized')
+    this.#renderer = new THREE.WebGLRenderer({
+      canvas: this.canvas,
+      antialias: true,
+      preserveDrawingBuffer: true,
+    })
+
+    // Reset previous state
+    this.#scaledTimeUpdaters.map((updater) => updater.reset())
+    this.#passMaterials = []
+    this.#renderTargets = []
+    this.#scene.children.forEach((child) => {
+      if (child instanceof THREE.Mesh) {
+        this.#scene.remove(child)
+      }
+    })
+
+    // Get canvas size & set initial uniforms
+    const size = [detail.canvas.width, detail.canvas.height]
+    this.#uniforms = {
+      ...this.#uniforms,
+      [uniformNames.renderSize]: { value: size },
+      [uniformNames.time]: { value: 0 },
     }
 
-    init(detail: DetailWebGL2) {
-        if (!this.canvas) throw new Error('Canvas not initialized');
-        this.#renderer = new THREE.WebGLRenderer({
-            canvas: this.canvas,
-            antialias: true,
-            preserveDrawingBuffer: true
-        });
+    // Create pass materials
+    const passBufferCount =
+      findLargestSuffixNum(this.#fragShader, uniformNames.passBuffer) + 1
+    for (let i = 0; i < passBufferCount; i++) {
+      this.#uniforms[`${uniformNames.passBuffer}${i}`] = { value: null }
+      this.#passMaterials.push(
+        new THREE.ShaderMaterial({
+          uniforms: this.#uniforms,
+          vertexShader: vertexShader,
+          fragmentShader: `#define ${PassDefPrefix}${i}\n${this.#fragShader}`,
+        })
+      )
 
-        // Reset previous state
-        this.#scaledTimeUpdaters.map((updater) => updater.reset());
-        this.#passMaterials = [];
-        this.#renderTargets = [];
-        this.#scene.children.forEach((child) => {
-            if (child instanceof THREE.Mesh) {
-                this.#scene.remove(child);
-            }
-        });
-
-        // Get canvas size & set initial uniforms
-        const size = [detail.canvas.width, detail.canvas.height];
-        this.#uniforms = {
-            ...this.#uniforms,
-            [uniformNames.renderSize]: { value: size },
-            [uniformNames.time]: { value: 0 }
-        };
-
-        // Create pass materials
-        const passBufferCount = findLargestSuffixNum(this.#fragShader, uniformNames.passBuffer) + 1;
-        for (let i = 0; i < passBufferCount; i++) {
-            this.#uniforms[`${uniformNames.passBuffer}${i}`] = { value: null };
-            this.#passMaterials.push(
-                new THREE.ShaderMaterial({
-                    uniforms: this.#uniforms,
-                    vertexShader: vertexShader,
-                    fragmentShader: `#define ${PassDefPrefix}${i}\n${this.#fragShader}`
-                })
-            );
-
-            // Add render targets, resized w/ canvas size
-            this.#renderTargets.push(new THREE.WebGLRenderTarget(size[0], size[1]));
-        }
-
-        // Set up last render
-        this.#finalPassMaterial = new THREE.ShaderMaterial({
-            uniforms: this.#uniforms,
-            vertexShader: vertexShader,
-            fragmentShader: this.#fragShader
-        });
-
-        // Add fresh quad
-        const geometry = new THREE.PlaneGeometry(2, 2);
-        const shaderMaterial = new THREE.ShaderMaterial({
-            uniforms: this.#uniforms,
-            vertexShader: vertexShader,
-            fragmentShader: this.#fragShader
-        });
-        this.#quad = new THREE.Mesh(geometry, shaderMaterial);
-        this.#scene.add(this.#quad);
+      // Add render targets, resized w/ canvas size
+      this.#renderTargets.push(new THREE.WebGLRenderTarget(size[0], size[1]))
     }
 
-    resized(detail: ResizedDetailWebGL2): void {
-        const size = detail.canvasSize;
-        if (!size) return;
-        this.#renderer?.setSize(size[0], size[1], false);
-        this.#uniforms[uniformNames.renderSize] = { value: size };
-        this.#renderTargets.forEach((renderTarget) => {
-            renderTarget.setSize(size[0], size[1]);
-        });
-        this.#render(this.#lastRenderedTime);
+    // Set up last render
+    this.#finalPassMaterial = new THREE.ShaderMaterial({
+      uniforms: this.#uniforms,
+      vertexShader: vertexShader,
+      fragmentShader: this.#fragShader,
+    })
+
+    // Add fresh quad
+    const geometry = new THREE.PlaneGeometry(2, 2)
+    const shaderMaterial = new THREE.ShaderMaterial({
+      uniforms: this.#uniforms,
+      vertexShader: vertexShader,
+      fragmentShader: this.#fragShader,
+    })
+    this.#quad = new THREE.Mesh(geometry, shaderMaterial)
+    this.#scene.add(this.#quad)
+  }
+
+  resized(detail: ResizedDetailWebGL2): void {
+    const size = detail.canvasSize
+    if (!size) return
+    this.#renderer?.setSize(size[0], size[1], false)
+    this.#uniforms[uniformNames.renderSize] = { value: size }
+    this.#renderTargets.forEach((renderTarget) => {
+      renderTarget.setSize(size[0], size[1])
+    })
+    this.#render(this.#lastRenderedTime)
+  }
+
+  destroy(detail: DetailWebGL2): void {
+    super.destroy(detail)
+    this.#renderer?.dispose()
+    this.#renderer = undefined
+    if (this.#nextAnimationFrame) {
+      cancelAnimationFrame(this.#nextAnimationFrame)
+      this.#nextAnimationFrame = null
+    }
+  }
+
+  update(detail: UpdateDetail<CanvasType>): void {
+    this.#render(detail.time)
+  }
+
+  /**
+   * Renders the scene and updates the uniforms
+   * @param time - The current time in seconds
+   */
+  #render(time: number) {
+    if (!this.#quad || !this.#finalPassMaterial || !this.#renderer) {
+      return
     }
 
-    destroy(detail: DetailWebGL2): void {
-        super.destroy(detail);
-        this.#renderer?.dispose();
-        this.#renderer = undefined;
-        if (this.#nextAnimationFrame) {
-            cancelAnimationFrame(this.#nextAnimationFrame);
-            this.#nextAnimationFrame = null;
-        }
+    // Update uniforms
+    this.#uniforms[uniformNames.time].value = time
+    this.#scaledTimeUpdaters.map((updater) => updater.update(time))
+    for (const uniformName of this.#paramUniformNames) {
+      const paramValue = Object.getOwnPropertyDescriptor(
+        this,
+        uniformName
+      )?.value
+      this.#uniforms[uniformName].value = paramValue
     }
 
-    update(detail: UpdateDetail<CanvasType>): void {
-        this.#render(detail.time);
+    // Render all render targets
+    for (let i = 0; i < this.#renderTargets.length; i++) {
+      const renderTarget = this.#renderTargets[i]
+      const passMaterial = this.#passMaterials[i]
+      this.#quad.material = passMaterial
+      this.#renderer.setRenderTarget(renderTarget)
+      this.#renderer.render(this.#scene, this.#camera)
+      this.#uniforms[`${uniformNames.passBuffer}${i}`].value =
+        renderTarget.texture
     }
 
-    /**
-     * Renders the scene and updates the uniforms
-     * @param time - The current time in seconds
-     */
-    #render(time: number) {
-        if (!this.#quad || !this.#finalPassMaterial || !this.#renderer) {
-            return;
-        }
+    // Render final pass
+    this.#quad.material = this.#finalPassMaterial
+    this.#renderer.setRenderTarget(null)
+    this.#renderer.render(this.#scene, this.#camera)
+    this.#lastRenderedTime = time
+  }
 
-        // Update uniforms
-        this.#uniforms[uniformNames.time].value = time;
-        this.#scaledTimeUpdaters.map((updater) => updater.update(time));
-        for (const uniformName of this.#paramUniformNames) {
-            const paramValue = Object.getOwnPropertyDescriptor(this, uniformName)?.value;
-            this.#uniforms[uniformName].value = paramValue;
-        }
+  /**
+   * Scaled time is continuous, but the per-frame time increment changes based on an automatically
+   * added timeScale parameter. This is useful for animations with a configurable motion rate that
+   * should be continuous as the time scale changes.
+   */
+  #generateScaledTimeUpdater(uniformName: string): ScaledTimeUpdater {
+    // These variables are used to calculate the scaled time, and updated in a JS closure below
+    let lastFrameTime = 0
+    let totalScaledTime = 0
 
-        // Render all render targets
-        for (let i = 0; i < this.#renderTargets.length; i++) {
-            const renderTarget = this.#renderTargets[i];
-            const passMaterial = this.#passMaterials[i];
-            this.#quad.material = passMaterial;
-            this.#renderer.setRenderTarget(renderTarget);
-            this.#renderer.render(this.#scene, this.#camera);
-            this.#uniforms[`${uniformNames.passBuffer}${i}`].value = renderTarget.texture;
-        }
+    // Create the parameter property
+    const scaledTimeParamKey =
+      'timeScale' + uniformName.replace(uniformNames.scaledTime, '')
+    Object.defineProperty(this, scaledTimeParamKey, {
+      value: 1.0,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    })
 
-        // Render final pass
-        this.#quad.material = this.#finalPassMaterial;
-        this.#renderer.setRenderTarget(null);
-        this.#renderer.render(this.#scene, this.#camera);
-        this.#lastRenderedTime = time;
+    // Create the uniform
+    this.#uniforms[uniformName] = { value: 0 }
+
+    // Return a function that updates the uniform when called
+    return {
+      update: (time: number) => {
+        const scaleParamValue = Object.getOwnPropertyDescriptor(
+          this,
+          scaledTimeParamKey
+        )?.value
+        const elapsed = time - lastFrameTime
+        lastFrameTime = time
+        totalScaledTime += elapsed * scaleParamValue
+        this.#uniforms[uniformName].value = totalScaledTime
+      },
+      reset: () => {
+        lastFrameTime = 0
+        totalScaledTime = 0
+        this.#uniforms[uniformName] = { value: 0 }
+      },
     }
-
-    /**
-     * Scaled time is continuous, but the per-frame time increment changes based on an automatically
-     * added timeScale parameter. This is useful for animations with a configurable motion rate that
-     * should be continuous as the time scale changes.
-     */
-    #generateScaledTimeUpdater(uniformName: string): ScaledTimeUpdater {
-        // These variables are used to calculate the scaled time, and updated in a JS closure below
-        let lastFrameTime = 0;
-        let totalScaledTime = 0;
-
-        // Create the parameter property
-        const scaledTimeParamKey = 'timeScale' + uniformName.replace(uniformNames.scaledTime, '');
-        Object.defineProperty(this, scaledTimeParamKey, {
-            value: 1.0,
-            writable: true,
-            enumerable: true,
-            configurable: true
-        });
-
-        // Create the uniform
-        this.#uniforms[uniformName] = { value: 0 };
-
-        // Return a function that updates the uniform when called
-        return {
-            update: (time: number) => {
-                const scaleParamValue = Object.getOwnPropertyDescriptor(
-                    this,
-                    scaledTimeParamKey
-                )?.value;
-                const elapsed = time - lastFrameTime;
-                lastFrameTime = time;
-                totalScaledTime += elapsed * scaleParamValue;
-                this.#uniforms[uniformName].value = totalScaledTime;
-            },
-            reset: () => {
-                lastFrameTime = 0;
-                totalScaledTime = 0;
-                this.#uniforms[uniformName] = { value: 0 };
-            }
-        };
-    }
+  }
 }
 
 // Finds the largest numbered suffix in a string (e.g. finds the largest PASS_X number in a string)
 function findLargestSuffixNum(sourceStr: string, prefix: string): number {
-    const regex = new RegExp(`${prefix}(\\d+)`, 'g');
-    let match;
-    let largestNumber = -1;
+  const regex = new RegExp(`${prefix}(\\d+)`, 'g')
+  let match
+  let largestNumber = -1
 
-    while ((match = regex.exec(sourceStr)) !== null) {
-        const number = parseInt(match[1], 10);
-        if (number > largestNumber) {
-            largestNumber = number;
-        }
+  while ((match = regex.exec(sourceStr)) !== null) {
+    const number = parseInt(match[1], 10)
+    if (number > largestNumber) {
+      largestNumber = number
     }
+  }
 
-    return largestNumber;
+  return largestNumber
 }

--- a/references/Project.ts
+++ b/references/Project.ts
@@ -8,88 +8,88 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 export default abstract class Project {
-    /**
-     * A canvas element that this project can draw to. This will be set automatically before init
-     * is called, and the size will be set to fill to the container div (its parent). It will be
-     * undefined if accessed in a project's constructor, or when using CanvasType.None (below).
-     */
-    canvas?: HTMLCanvasElement;
+  /**
+   * A canvas element that this project can draw to. This will be set automatically before init
+   * is called, and the size will be set to fill to the container div (its parent). It will be
+   * undefined if accessed in a project's constructor, or when using CanvasType.None (below).
+   */
+  canvas?: HTMLCanvasElement
 
-    /**
-     * A div element that this project will use as a container. This will be set automatically
-     * before init is called, and the container div will fill as much space as possible (dependant
-     * on your layout configuration). It is only undefined if accessed in a project's constructor.
-     */
-    container?: HTMLDivElement;
+  /**
+   * A div element that this project will use as a container. This will be set automatically
+   * before init is called, and the container div will fill as much space as possible (dependant
+   * on your layout configuration). It is only undefined if accessed in a project's constructor.
+   */
+  container?: HTMLDivElement
 
-    /**
-     * The canvasType used by this project; similarly typed canvases will be reused as new projects
-     * are loaded. The canvasType selected should match the type of context you expect to use with
-     * this.canvas.getContext(), or CanvasType.None if you don't need a canvas. This should be set
-     * in the project's constructor, and should not be changed during the project's lifecycle.
-     */
-    canvasType: CanvasType = CanvasType.Context2D;
+  /**
+   * The canvasType used by this project; similarly typed canvases will be reused as new projects
+   * are loaded. The canvasType selected should match the type of context you expect to use with
+   * this.canvas.getContext(), or CanvasType.None if you don't need a canvas. This should be set
+   * in the project's constructor, and should not be changed during the project's lifecycle.
+   */
+  canvasType: CanvasType = CanvasType.Context2D
 
-    /**
-     * An array of instance variable names that should be ignored when loading parameters. Beyond
-     * the default set of ignored keys, you can add any other keys that you don't want to be
-     * considered parameters. This should be set in the project's constructor, and should not be
-     * changed during the project's lifecycle.
-     */
-    ignoreKeys: string[] = [];
+  /**
+   * An array of instance variable names that should be ignored when loading parameters. Beyond
+   * the default set of ignored keys, you can add any other keys that you don't want to be
+   * considered parameters. This should be set in the project's constructor, and should not be
+   * changed during the project's lifecycle.
+   */
+  ignoreKeys: string[] = []
 
-    /**
-     * `init` is called once when the project is first loaded, after this.canvas and this.container
-     * become available. Override this with any custom initialization behavior.
-     *
-     * @param detail - An object containing references to the `canvas` object, canvas `context`, and
-     * the `container` div.
-     */
-    init(detail: Detail<typeof this.canvasType>) {}
+  /**
+   * `init` is called once when the project is first loaded, after this.canvas and this.container
+   * become available. Override this with any custom initialization behavior.
+   *
+   * @param detail - An object containing references to the `canvas` object, canvas `context`, and
+   * the `container` div.
+   */
+  init(detail: Detail<typeof this.canvasType>) {}
 
-    /**
-     * `update` is called continuously in a `requestAnimationFrame` loop. Override this with your
-     * custom drawing code.
-     *
-     * @param detail - An object containing references to the `canvas` object, canvas `context`, and
-     * the `container` div, as well as canvas `width` and `height`, `frame` count and `time` in
-     * seconds since the project was loaded, and an array of `paramsChanged` (keys) since the last
-     * `update` call.
-     */
-    update(detail: UpdateDetail<typeof this.canvasType>) {}
+  /**
+   * `update` is called continuously in a `requestAnimationFrame` loop. Override this with your
+   * custom drawing code.
+   *
+   * @param detail - An object containing references to the `canvas` object, canvas `context`, and
+   * the `container` div, as well as canvas `width` and `height`, `frame` count and `time` in
+   * seconds since the project was loaded, and an array of `paramsChanged` (keys) since the last
+   * `update` call.
+   */
+  update(detail: UpdateDetail<typeof this.canvasType>) {}
 
-    /**
-     * `paramsChanged` is called when one or more parameters are changed in the UI.
-     *
-     * @param detail - An object containing references to the `canvas` object, canvas `context`, and
-     * the `container` div, as well as an array of `keys` of the parameters that were changed.
-     */
-    paramsChanged(detail: ParamsChangedDetail<typeof this.canvasType>) {}
+  /**
+   * `paramsChanged` is called when one or more parameters are changed in the UI.
+   *
+   * @param detail - An object containing references to the `canvas` object, canvas `context`, and
+   * the `container` div, as well as an array of `keys` of the parameters that were changed.
+   */
+  paramsChanged(detail: ParamsChangedDetail<typeof this.canvasType>) {}
 
-    /**
-     * `resized` is called when the container div and/or active canvas is resized.
-     *
-     * @param detail - An object containing references to the `canvas` object, canvas `context`, and
-     * the `container` div, as well as the new `containerSize` and `canvasSize` (if using a canvas).
-     * Note that `canvasSize` is the DOM element size, and _not_ the canvas drawing size, which is
-     * scaled by the current pixel ratio.
-     */
-    resized(detail: ResizedDetail<typeof this.canvasType>) {}
+  /**
+   * `resized` is called when the container div and/or active canvas is resized.
+   *
+   * @param detail - An object containing references to the `canvas` object, canvas `context`, and
+   * the `container` div, as well as the new `containerSize` and `canvasSize` (if using a canvas).
+   * Note that `canvasSize` is the DOM element size, and _not_ the canvas drawing size, which is
+   * scaled by the current pixel ratio.
+   */
+  resized(detail: ResizedDetail<typeof this.canvasType>) {}
 
-    /**
-     * `destroy` is called when the project is unloaded, i.e. when another project is selected.
-     * Override this with any custom cleanup behavior.
-     *
-     * @param detail - An object containing references to the `canvas` object, canvas `context`, and
-     * the `container` div.
-     */
-    destroy(detail: Detail<typeof this.canvasType>) {
-        // By default, clear the shared canvas when the project is unloaded.
-        const context = this.canvas?.getContext('2d');
-        if (context && this.canvas) {
-            context.clearRect(0, 0, this.canvas.width, this.canvas.height);
-        }
+  /**
+   * `destroy` is called when the project is unloaded, i.e. when another project is selected.
+   * Override this with any custom cleanup behavior.
+   *
+   * @param detail - An object containing references to the `canvas` object, canvas `context`, and
+   * the `container` div.
+   */
+  destroy(detail: Detail<typeof this.canvasType>) {
+    // By default, clear the shared canvas when the project is unloaded.
+    const context = this.canvas?.getContext('2d')
+    if (context && this.canvas) {
+      context.clearRect(0, 0, this.canvas.width, this.canvas.height)
     }
+  }
 }
 
 /**
@@ -99,11 +99,11 @@ export default abstract class Project {
  * has not yet been determined.
  */
 export enum CanvasType {
-    Context2D = '2d',
-    WebGL = 'webgl',
-    WebGL2 = 'webgl2',
-    None = 'none',
-    Unknown = 'unknown'
+  Context2D = '2d',
+  WebGL = 'webgl',
+  WebGL2 = 'webgl2',
+  None = 'none',
+  Unknown = 'unknown',
 }
 
 /**
@@ -116,27 +116,27 @@ export enum CanvasType {
  * - `context`: the canvas context that the project will draw to, if using a canvas.
  */
 export type Detail<T extends CanvasType = CanvasType.Unknown> = {
-    container: HTMLDivElement;
-    canvas: T extends CanvasType.None
-        ? undefined
-        : T extends CanvasType.Unknown
-        ? HTMLCanvasElement | undefined
-        : HTMLCanvasElement;
-    context: T extends CanvasType.None
-        ? undefined
-        : T extends CanvasType.Context2D
-        ? CanvasRenderingContext2D
-        : T extends CanvasType.WebGL
+  container: HTMLDivElement
+  canvas: T extends CanvasType.None
+    ? undefined
+    : T extends CanvasType.Unknown
+      ? HTMLCanvasElement | undefined
+      : HTMLCanvasElement
+  context: T extends CanvasType.None
+    ? undefined
+    : T extends CanvasType.Context2D
+      ? CanvasRenderingContext2D
+      : T extends CanvasType.WebGL
         ? WebGLRenderingContext
         : T extends CanvasType.WebGL2
-        ? WebGL2RenderingContext
-        : T extends CanvasType.Unknown
-        ? RenderingContext | null | undefined
-        : never;
-};
-export type Detail2D = Detail<CanvasType.Context2D>;
-export type DetailWebGL = Detail<CanvasType.WebGL>;
-export type DetailWebGL2 = Detail<CanvasType.WebGL2>;
+          ? WebGL2RenderingContext
+          : T extends CanvasType.Unknown
+            ? RenderingContext | null | undefined
+            : never
+}
+export type Detail2D = Detail<CanvasType.Context2D>
+export type DetailWebGL = Detail<CanvasType.WebGL>
+export type DetailWebGL2 = Detail<CanvasType.WebGL2>
 
 /**
  * Detail object type used with the project's `update` method. In addition to `Detail` fields,
@@ -147,36 +147,38 @@ export type DetailWebGL2 = Detail<CanvasType.WebGL2>;
  * - `width`: the width of the canvas, if using a canvas.
  * - `height`: the height of the canvas, if using a canvas.
  */
-export type UpdateDetail<T extends CanvasType = CanvasType.Unknown> = Detail<T> & {
-    frame: number;
-    time: number;
-    paramsChanged: string[];
+export type UpdateDetail<T extends CanvasType = CanvasType.Unknown> =
+  Detail<T> & {
+    frame: number
+    time: number
+    paramsChanged: string[]
     width: T extends CanvasType.None
-        ? undefined
-        : T extends CanvasType.Unknown
+      ? undefined
+      : T extends CanvasType.Unknown
         ? number | undefined
-        : number;
+        : number
     height: T extends CanvasType.None
-        ? undefined
-        : T extends CanvasType.Unknown
+      ? undefined
+      : T extends CanvasType.Unknown
         ? number | undefined
-        : number;
-};
-export type UpdateDetail2D = UpdateDetail<CanvasType.Context2D>;
-export type UpdateDetailWebGL = UpdateDetail<CanvasType.WebGL>;
-export type UpdateDetailWebGL2 = UpdateDetail<CanvasType.WebGL2>;
+        : number
+  }
+export type UpdateDetail2D = UpdateDetail<CanvasType.Context2D>
+export type UpdateDetailWebGL = UpdateDetail<CanvasType.WebGL>
+export type UpdateDetailWebGL2 = UpdateDetail<CanvasType.WebGL2>
 
 /**
  * Detail object type used with the project's `paramsChanged` method. In addition to `Detail`
  * fields, `ParamsChangedDetail` contains the following:
  * - `keys`: the keys of any parameters that were changed
  */
-export type ParamsChangedDetail<T extends CanvasType = CanvasType.Unknown> = Detail<T> & {
-    keys: string;
-};
-export type ParamsChangedDetail2D = ParamsChangedDetail<CanvasType.Context2D>;
-export type ParamsChangedDetailWebGL = ParamsChangedDetail<CanvasType.WebGL>;
-export type ParamsChangedDetailWebGL2 = ParamsChangedDetail<CanvasType.WebGL2>;
+export type ParamsChangedDetail<T extends CanvasType = CanvasType.Unknown> =
+  Detail<T> & {
+    keys: string
+  }
+export type ParamsChangedDetail2D = ParamsChangedDetail<CanvasType.Context2D>
+export type ParamsChangedDetailWebGL = ParamsChangedDetail<CanvasType.WebGL>
+export type ParamsChangedDetailWebGL2 = ParamsChangedDetail<CanvasType.WebGL2>
 
 /**
  * Detail object type used with the project's resized method. In addition to `Detail` fields,
@@ -187,10 +189,11 @@ export type ParamsChangedDetailWebGL2 = ParamsChangedDetail<CanvasType.WebGL2>;
  * Note that `canvasSize` is unlikely to correspond to `[this.canvas.width, this.canvas.height]`, as
  * the canvas drawing size is scaled by the current pixel ratio.
  */
-export type ResizedDetail<T extends CanvasType = CanvasType.Unknown> = Detail<T> & {
-    containerSize: [number, number];
-    canvasSize?: [number, number];
-};
-export type ResizedDetail2D = ResizedDetail<CanvasType.Context2D>;
-export type ResizedDetailWebGL = ResizedDetail<CanvasType.WebGL>;
-export type ResizedDetailWebGL2 = ResizedDetail<CanvasType.WebGL2>;
+export type ResizedDetail<T extends CanvasType = CanvasType.Unknown> =
+  Detail<T> & {
+    containerSize: [number, number]
+    canvasSize?: [number, number]
+  }
+export type ResizedDetail2D = ResizedDetail<CanvasType.Context2D>
+export type ResizedDetailWebGL = ResizedDetail<CanvasType.WebGL>
+export type ResizedDetailWebGL2 = ResizedDetail<CanvasType.WebGL2>

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,6 @@
-html, body, #root {
+html,
+body,
+#root {
   height: 100%;
   margin: 0;
 }

--- a/src/components/FeedbackPlane.tsx
+++ b/src/components/FeedbackPlane.tsx
@@ -8,11 +8,7 @@ export default function FeedbackPlane({ texture }: Props) {
   return (
     <mesh scale={[viewport.width, viewport.height, 1]} position-z={0}>
       <planeGeometry args={[1, 1]} />
-      <meshBasicMaterial
-        map={texture}
-        transparent
-        toneMapped={false}
-      />
+      <meshBasicMaterial map={texture} transparent toneMapped={false} />
     </mesh>
   )
 }

--- a/src/components/ForegroundLayer.tsx
+++ b/src/components/ForegroundLayer.tsx
@@ -10,11 +10,18 @@ type Props = {
   size?: SvgSize
 }
 
-export default function ForegroundLayer({ url, color = '#ffffff', size = { type: 'scaled', factor: 0.01 } }: Props) {
+export default function ForegroundLayer({
+  url,
+  color = '#ffffff',
+  size = { type: 'scaled', factor: 0.01 },
+}: Props) {
   const { viewport } = useThree()
   const { paths } = useLoader(SVGLoader, url)
   const shapes = useMemo(() => paths.flatMap((p) => p.toShapes(true)), [paths])
-  const geometries = useMemo(() => shapes.map((shape) => new THREE.ShapeGeometry(shape)), [shapes])
+  const geometries = useMemo(
+    () => shapes.map((shape) => new THREE.ShapeGeometry(shape)),
+    [shapes]
+  )
   const bounds = useMemo(() => {
     const box = new THREE.Box3()
     geometries.forEach((g) => {

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -1,65 +1,66 @@
-import { a } from "@react-spring/three";
-import { useEffect, useState } from "react";
-import { Pane } from "tweakpane";
-import defaultSvgUrl from "../assets/diamond.svg?url";
-import useDragAndSpring from "../hooks/useDragAndSpring";
-import useFeedbackFBO from "../hooks/useFeedbackFBO";
-import motionBlurFrag from "../shaders/motionBlur.frag";
-import randomPaintFrag from "../shaders/randomPaint.frag";
-import FeedbackPlane from "./FeedbackPlane";
-import ForegroundLayer from "./ForegroundLayer";
+import { a } from '@react-spring/three'
+import { useEffect, useState } from 'react'
+import { Pane } from 'tweakpane'
+import defaultSvgUrl from '../assets/diamond.svg?url'
+import useDragAndSpring from '../hooks/useDragAndSpring'
+import useFeedbackFBO from '../hooks/useFeedbackFBO'
+import motionBlurFrag from '../shaders/motionBlur.frag'
+import randomPaintFrag from '../shaders/randomPaint.frag'
+import FeedbackPlane from './FeedbackPlane'
+import ForegroundLayer from './ForegroundLayer'
 
 function useSvgUrl(): string {
-  const params = new URLSearchParams(window.location.search);
-  return params.get("svg") || defaultSvgUrl;
+  const params = new URLSearchParams(window.location.search)
+  return params.get('svg') || defaultSvgUrl
 }
 
 export default function ForegroundLayerDemo() {
-  const svgUrl = useSvgUrl();
-  const { bind, pose, active } = useDragAndSpring();
+  const svgUrl = useSvgUrl()
+  const { bind, pose, active, interactionSession } = useDragAndSpring()
   const shaderMap = {
     motionBlur: motionBlurFrag,
     randomPaint: randomPaintFrag,
-  };
+  }
   const [shaderName, setShaderName] =
-    useState<keyof typeof shaderMap>("motionBlur");
-  const [decay, setDecay] = useState(0.9);
+    useState<keyof typeof shaderMap>('motionBlur')
+  const [decay, setDecay] = useState(0.9)
 
   useEffect(() => {
-    const pane = new Pane();
+    const pane = new Pane()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const shaderInput = (pane as any).addBlade({
-      view: "list",
-      label: "shader",
+      view: 'list',
+      label: 'shader',
       options: [
-        { text: "Motion Blur", value: "motionBlur" },
-        { text: "Random Paint", value: "randomPaint" },
+        { text: 'Motion Blur', value: 'motionBlur' },
+        { text: 'Random Paint', value: 'randomPaint' },
       ],
       value: shaderName,
-    });
+    })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    shaderInput.on("change", (ev: any) =>
+    shaderInput.on('change', (ev: any) =>
       setShaderName(ev.value as keyof typeof shaderMap)
-    );
+    )
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const decayInput = (pane as any).addBlade({
-      view: "slider",
-      label: "decay",
+      view: 'slider',
+      label: 'decay',
       min: 0,
       max: 1,
       value: decay,
-    });
+    })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    decayInput.on("change", (ev: any) => setDecay(ev.value));
+    decayInput.on('change', (ev: any) => setDecay(ev.value))
 
-    return () => pane.dispose();
-  }, []);
+    return () => pane.dispose()
+  }, [])
 
   const { snapshotRef, texture } = useFeedbackFBO(
     shaderMap[shaderName],
     decay,
-    active
-  );
+    active,
+    interactionSession
+  )
   return (
     <>
       <FeedbackPlane texture={texture} />
@@ -72,9 +73,9 @@ export default function ForegroundLayerDemo() {
         <ForegroundLayer
           url={svgUrl}
           color="#000000"
-          size={{ type: "scaled", factor: 0.01 }}
+          size={{ type: 'scaled', factor: 0.01 }}
         />
       </a.group>
     </>
-  );
+  )
 }

--- a/src/hooks/useDragAndSpring.ts
+++ b/src/hooks/useDragAndSpring.ts
@@ -27,6 +27,7 @@ export default function useDragAndSpring() {
   const [isDragging, setDragging] = useState(false)
   const [isSpringing, setSpringing] = useState(false)
   const [spring, api] = useSpring(() => ({ x: 0, y: 0 }))
+  const [interactionSession, setInteractionSession] = useState(0)
 
   const onPointerEnter = useCallback(() => {
     overRef.current = true
@@ -35,6 +36,7 @@ export default function useDragAndSpring() {
 
   const onPointerDown = useCallback(
     (e: PointerEvent) => {
+      setInteractionSession((s) => s + 1)
       setDragging(true)
       setCursor('grabbing')
       startRef.current = {
@@ -53,7 +55,11 @@ export default function useDragAndSpring() {
       if (!isDragging) return
       const dx = (e.clientX - startRef.current.sx) * factorX
       const dy = -(e.clientY - startRef.current.sy) * factorY
-      api.start({ x: startRef.current.bx + dx, y: startRef.current.by + dy, immediate: true })
+      api.start({
+        x: startRef.current.bx + dx,
+        y: startRef.current.by + dy,
+        immediate: true,
+      })
     },
     [api, factorX, factorY, isDragging]
   )
@@ -88,5 +94,6 @@ export default function useDragAndSpring() {
     },
     pose: spring,
     active: isDragging || isSpringing,
+    interactionSession,
   }
 }

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -1,6 +1,6 @@
-import { useFrame, useThree } from "@react-three/fiber";
-import { useEffect, useMemo, useRef } from "react";
-import * as THREE from "three";
+import { useFrame, useThree } from '@react-three/fiber'
+import { useEffect, useMemo, useRef } from 'react'
+import * as THREE from 'three'
 
 const vertexShader = `
   varying vec2 vUv;
@@ -8,26 +8,27 @@ const vertexShader = `
     vUv = uv;
     gl_Position = vec4(position, 1.0);
   }
-`;
+`
 
 export default function useFeedbackFBO(
   fragmentShader: string,
   decay = 0.9,
-  active = true
+  active = true,
+  sessionId = 0
 ) {
-  const { gl, size, camera } = useThree();
+  const { gl, size, camera } = useThree()
 
-  const snapshotGroup = useRef<THREE.Group | null>(null);
+  const snapshotGroup = useRef<THREE.Group | null>(null)
 
   const sessionRandom = useRef(
     new THREE.Vector3(Math.random(), Math.random(), Math.random())
-  );
+  )
 
-  const readRT = useRef(new THREE.WebGLRenderTarget(size.width, size.height));
-  const writeRT = useRef(new THREE.WebGLRenderTarget(size.width, size.height));
+  const readRT = useRef(new THREE.WebGLRenderTarget(size.width, size.height))
+  const writeRT = useRef(new THREE.WebGLRenderTarget(size.width, size.height))
   const snapshotRT = useRef(
     new THREE.WebGLRenderTarget(size.width, size.height)
-  );
+  )
 
   const uniforms = useMemo(
     () => ({
@@ -37,68 +38,68 @@ export default function useFeedbackFBO(
       uSessionRandom: { value: sessionRandom.current.clone() },
     }),
     [decay]
-  );
+  )
 
   const quadScene = useMemo(() => {
-    const scene = new THREE.Scene();
+    const scene = new THREE.Scene()
     const material = new THREE.ShaderMaterial({
       vertexShader,
       fragmentShader,
       uniforms,
-      transparent: true,
-    });
-    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), material);
-    scene.add(mesh);
-    return scene;
-  }, [fragmentShader, uniforms]);
+      blending: THREE.NoBlending,
+    })
+    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), material)
+    scene.add(mesh)
+    return scene
+  }, [fragmentShader, uniforms])
 
   const orthoCam = useMemo(
     () => new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1),
     []
-  );
+  )
 
   useEffect(() => {
-    sessionRandom.current.set(Math.random(), Math.random(), Math.random());
-    uniforms.uSessionRandom.value.copy(sessionRandom.current);
-  }, [active, uniforms]);
+    sessionRandom.current.set(Math.random(), Math.random(), Math.random())
+    uniforms.uSessionRandom.value.copy(sessionRandom.current)
+  }, [sessionId, uniforms])
 
   useEffect(() => {
-    readRT.current.setSize(size.width, size.height);
-    writeRT.current.setSize(size.width, size.height);
-    snapshotRT.current.setSize(size.width, size.height);
-  }, [size]);
+    readRT.current.setSize(size.width, size.height)
+    writeRT.current.setSize(size.width, size.height)
+    snapshotRT.current.setSize(size.width, size.height)
+  }, [size])
 
   useEffect(() => {
-    const read = readRT.current;
-    const write = writeRT.current;
-    const snap = snapshotRT.current;
+    const read = readRT.current
+    const write = writeRT.current
+    const snap = snapshotRT.current
     return () => {
-      read.dispose();
-      write.dispose();
-      snap.dispose();
-    };
-  }, []);
+      read.dispose()
+      write.dispose()
+      snap.dispose()
+    }
+  }, [])
 
   useFrame(() => {
     // Prepare snapshot texture
-    gl.setRenderTarget(snapshotRT.current);
-    gl.setClearColor(0x000000, 0);
-    gl.clear(true, true, true);
+    gl.setRenderTarget(snapshotRT.current)
+    gl.setClearColor(0x000000, 0)
+    gl.clear(true, true, true)
     if (active && snapshotGroup.current) {
-      gl.render(snapshotGroup.current, camera);
+      gl.render(snapshotGroup.current, camera)
     }
 
     // Feedback pass
-    gl.setRenderTarget(writeRT.current);
-    gl.render(quadScene, orthoCam);
-    gl.setRenderTarget(null);
+    gl.setRenderTarget(writeRT.current)
+    gl.render(quadScene, orthoCam)
+    gl.setRenderTarget(null)
 
     // Swap
-    const tmp = readRT.current;
-    readRT.current = writeRT.current;
-    writeRT.current = tmp;
-    uniforms.uPrevFrame.value = readRT.current.texture;
-  });
+    const tmp = readRT.current
+    readRT.current = writeRT.current
+    writeRT.current = tmp
+    uniforms.uPrevFrame.value = readRT.current.texture
+  })
 
-  return { snapshotRef: snapshotGroup, texture: readRT.current.texture };
+  return { snapshotRef: snapshotGroup, texture: readRT.current.texture }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,5 +6,5 @@ import App from './App.tsx'
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
+  </StrictMode>
 )


### PR DESCRIPTION
## Summary
- add Prettier configuration and format all files
- reset uSessionRandom only when a drag begins
- disable blending in feedback pass to preserve color

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68646eae140c8332a3d60120ff07df00