### PR TITLE
Add distance-based interpolator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,10 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **19** – Switched intra-frame blending to full-opacity normal mode to avoid dark trails and maintain union of poses. Lint and build pass.
 - **20** – Fixed snapshot compositing by disabling autoClear and removing unnecessary material resets. Interpolated poses now accumulate correctly. Lint and build pass.
 - **21** – Flushed interpolation queue when inactive so spring trails don't appear later. Lint and build pass.
+- **22** – Switched interpolator to distance-based step sizing with dynamic counts. Lint and build pass.
 
 ## Next Steps
 
 - Tune random paint blending for performance and visual quality.
-- Experiment with interpolation step counts and potential spline curves.
+- Experiment with interpolation step sizes and potential spline curves.
 - Explore path-based interpolation curves for even smoother motion.

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -18,8 +18,8 @@ function useSvgUrl(): string {
 export default function ForegroundLayerDemo() {
   const svgUrl = useSvgUrl()
   const { bind, pose, active, interactionSession } = useDragAndSpring()
-  const [interpSteps, setInterpSteps] = useState(4)
-  const interpQueue = useFrameInterpolator(pose, interpSteps)
+  const [stepSize, setStepSize] = useState(0.25)
+  const interpQueue = useFrameInterpolator(pose, stepSize)
   const shaderMap = {
     motionBlur: motionBlurFrag,
     randomPaint: randomPaintFrag,
@@ -57,14 +57,14 @@ export default function ForegroundLayerDemo() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const interpInput = (pane as any).addBlade({
       view: 'slider',
-      label: 'interp',
-      min: 1,
-      max: 20,
-      value: interpSteps,
-      step: 1,
+      label: 'step',
+      min: 0.05,
+      max: 1,
+      value: stepSize,
+      step: 0.05,
     })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    interpInput.on('change', (ev: any) => setInterpSteps(ev.value))
+    interpInput.on('change', (ev: any) => setStepSize(ev.value))
 
     return () => pane.dispose()
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/hooks/useFrameInterpolator.ts
+++ b/src/hooks/useFrameInterpolator.ts
@@ -6,7 +6,7 @@ import type { DragSpringPose } from './useDragAndSpring'
 
 export default function useFrameInterpolator(
   pose: { x: SpringValue<number>; y: SpringValue<number> },
-  steps = 4
+  stepSize = 0.25
 ): MutableRefObject<DragSpringPose[]> {
   const lastPose = useRef<DragSpringPose>({
     x: pose.x.get(),
@@ -17,11 +17,15 @@ export default function useFrameInterpolator(
   useFrame(() => {
     const current = { x: pose.x.get(), y: pose.y.get() }
     if (current.x !== lastPose.current.x || current.y !== lastPose.current.y) {
+      const dx = current.x - lastPose.current.x
+      const dy = current.y - lastPose.current.y
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      const steps = Math.max(1, Math.ceil(dist / stepSize))
       for (let i = 1; i <= steps; i++) {
         const t = i / steps
         queue.current.push({
-          x: lastPose.current.x + (current.x - lastPose.current.x) * t,
-          y: lastPose.current.y + (current.y - lastPose.current.y) * t,
+          x: lastPose.current.x + dx * t,
+          y: lastPose.current.y + dy * t,
         })
       }
       lastPose.current = current


### PR DESCRIPTION
## Summary
- use step size instead of step count in `useFrameInterpolator`
- expose new `step` control in `ForegroundLayerDemo`
- log change and update next steps in AGENTS

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864b26e5dc88332a96b6dea02f93cef