### PR TITLE
Implement pixel-based interpolation and DPR-aware FBOs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,10 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **20** – Fixed snapshot compositing by disabling autoClear and removing unnecessary material resets. Interpolated poses now accumulate correctly. Lint and build pass.
 - **21** – Flushed interpolation queue when inactive so spring trails don't appear later. Lint and build pass.
 - **22** – Switched interpolator to distance-based step sizing with dynamic counts. Lint and build pass.
+- **23** – Converted interpolation step controls to pixel units and resized all FBOs using device pixel ratio. Lint and build pass.
 
 ## Next Steps
 
 - Tune random paint blending for performance and visual quality.
-- Experiment with interpolation step sizes and potential spline curves.
 - Explore path-based interpolation curves for even smoother motion.
+- Profile high-DPR rendering performance and optimize FBO sizing.

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -18,7 +18,7 @@ function useSvgUrl(): string {
 export default function ForegroundLayerDemo() {
   const svgUrl = useSvgUrl()
   const { bind, pose, active, interactionSession } = useDragAndSpring()
-  const [stepSize, setStepSize] = useState(0.25)
+  const [stepSize, setStepSize] = useState(20)
   const interpQueue = useFrameInterpolator(pose, stepSize)
   const shaderMap = {
     motionBlur: motionBlurFrag,
@@ -57,11 +57,11 @@ export default function ForegroundLayerDemo() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const interpInput = (pane as any).addBlade({
       view: 'slider',
-      label: 'step',
-      min: 0.05,
-      max: 1,
+      label: 'step(px)',
+      min: 5,
+      max: 200,
       value: stepSize,
-      step: 0.05,
+      step: 5,
     })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     interpInput.on('change', (ev: any) => setStepSize(ev.value))

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -21,6 +21,7 @@ export default function useFeedbackFBO(
   interpQueue?: MutableRefObject<DragSpringPose[]>
 ) {
   const { gl, size, camera } = useThree()
+  const dpr = gl.getPixelRatio()
 
   const snapshotGroup = useRef<THREE.Group | null>(null)
 
@@ -28,10 +29,14 @@ export default function useFeedbackFBO(
     new THREE.Vector3(Math.random(), Math.random(), Math.random())
   )
 
-  const readRT = useRef(new THREE.WebGLRenderTarget(size.width, size.height))
-  const writeRT = useRef(new THREE.WebGLRenderTarget(size.width, size.height))
+  const readRT = useRef(
+    new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr)
+  )
+  const writeRT = useRef(
+    new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr)
+  )
   const snapshotRT = useRef(
-    new THREE.WebGLRenderTarget(size.width, size.height)
+    new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr)
   )
 
   const uniforms = useMemo(
@@ -68,10 +73,11 @@ export default function useFeedbackFBO(
   }, [sessionId, uniforms])
 
   useEffect(() => {
-    readRT.current.setSize(size.width, size.height)
-    writeRT.current.setSize(size.width, size.height)
-    snapshotRT.current.setSize(size.width, size.height)
-  }, [size])
+    const ratio = gl.getPixelRatio()
+    readRT.current.setSize(size.width * ratio, size.height * ratio)
+    writeRT.current.setSize(size.width * ratio, size.height * ratio)
+    snapshotRT.current.setSize(size.width * ratio, size.height * ratio)
+  }, [size, gl])
 
   useEffect(() => {
     const read = readRT.current


### PR DESCRIPTION
## Summary
- resize feedback FBOs according to the browser's device pixel ratio
- measure interpolation step sizes in screen pixels
- expose step size slider in pixels via tweakpane
- document the change in `AGENTS.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864b51bedf883328d5c5c1603bdfd41