### PR TITLE
Add grouped tweakpane controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,11 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **21** – Flushed interpolation queue when inactive so spring trails don't appear later. Lint and build pass.
 - **22** – Switched interpolator to distance-based step sizing with dynamic counts. Lint and build pass.
 - **23** – Converted interpolation step controls to pixel units and resized all FBOs using device pixel ratio. Lint and build pass.
+- **24** – Updated Tweakpane controls with grouped folders. Decay now ranges 0.8–1, step is 1–25 with integer increments, and SVG size is configurable via dropdown and parameter blades. Lint and build pass.
 
 ## Next Steps
 
 - Tune random paint blending for performance and visual quality.
 - Explore path-based interpolation curves for even smoother motion.
 - Profile high-DPR rendering performance and optimize FBO sizing.
+- Expose additional shader uniforms via Tweakpane for experimentation.

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -9,6 +9,7 @@ import motionBlurFrag from '../shaders/motionBlur.frag'
 import randomPaintFrag from '../shaders/randomPaint.frag'
 import FeedbackPlane from './FeedbackPlane'
 import ForegroundLayer from './ForegroundLayer'
+import type { SvgSize } from '../types/svg'
 
 function useSvgUrl(): string {
   const params = new URLSearchParams(window.location.search)
@@ -19,6 +20,10 @@ export default function ForegroundLayerDemo() {
   const svgUrl = useSvgUrl()
   const { bind, pose, active, interactionSession } = useDragAndSpring()
   const [stepSize, setStepSize] = useState(20)
+  const [svgSize, setSvgSize] = useState<SvgSize>({
+    type: 'scaled',
+    factor: 0.01,
+  })
   const interpQueue = useFrameInterpolator(pose, stepSize)
   const shaderMap = {
     motionBlur: motionBlurFrag,
@@ -30,8 +35,14 @@ export default function ForegroundLayerDemo() {
 
   useEffect(() => {
     const pane = new Pane()
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const shaderInput = (pane as any).addBlade({
+    const effectFolder = (pane as any).addFolder({ title: 'Effect' })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fgFolder = (pane as any).addFolder({ title: 'Foreground' })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const shaderInput = (effectFolder as any).addBlade({
       view: 'list',
       label: 'shader',
       options: [
@@ -45,26 +56,88 @@ export default function ForegroundLayerDemo() {
       setShaderName(ev.value as keyof typeof shaderMap)
     )
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const decayInput = (pane as any).addBlade({
+    const decayInput = (effectFolder as any).addBlade({
       view: 'slider',
       label: 'decay',
-      min: 0,
+      min: 0.8,
       max: 1,
       value: decay,
     })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     decayInput.on('change', (ev: any) => setDecay(ev.value))
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const interpInput = (pane as any).addBlade({
+    const interpInput = (effectFolder as any).addBlade({
       view: 'slider',
       label: 'step(px)',
-      min: 5,
-      max: 200,
+      min: 1,
+      max: 25,
       value: stepSize,
-      step: 5,
+      step: 1,
     })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     interpInput.on('change', (ev: any) => setStepSize(ev.value))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sizeInput = (fgFolder as any).addBlade({
+      view: 'list',
+      label: 'size',
+      options: [
+        { text: 'Natural', value: 'natural' },
+        { text: 'Scaled', value: 'scaled' },
+        { text: 'Relative', value: 'relative' },
+      ],
+      value: svgSize.type,
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let paramBlade: any
+    const updateParamBlade = (type: SvgSize['type']) => {
+      if (paramBlade) fgFolder.remove(paramBlade)
+      if (type === 'scaled') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        paramBlade = (fgFolder as any).addBlade({
+          view: 'slider',
+          label: 'factor',
+          min: 0,
+          max: 0.1,
+          value: svgSize.type === 'scaled' ? svgSize.factor : 0.01,
+        })
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        paramBlade.on('change', (ev: any) =>
+          setSvgSize({ type: 'scaled', factor: ev.value })
+        )
+      } else if (type === 'relative') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        paramBlade = (fgFolder as any).addBlade({
+          view: 'slider',
+          label: 'fraction',
+          min: 0,
+          max: 1,
+          value: svgSize.type === 'relative' ? svgSize.fraction : 0.5,
+        })
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        paramBlade.on('change', (ev: any) =>
+          setSvgSize({ type: 'relative', fraction: ev.value })
+        )
+      } else {
+        paramBlade = undefined
+      }
+    }
+
+    updateParamBlade(svgSize.type)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sizeInput.on('change', (ev: any) => {
+      const type = ev.value as SvgSize['type']
+      if (type === 'natural') {
+        setSvgSize({ type: 'natural' })
+      } else if (type === 'scaled') {
+        setSvgSize({ type: 'scaled', factor: 0.01 })
+      } else if (type === 'relative') {
+        setSvgSize({ type: 'relative', fraction: 0.5 })
+      }
+      updateParamBlade(type)
+    })
 
     return () => pane.dispose()
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -86,11 +159,7 @@ export default function ForegroundLayerDemo() {
         position-y={pose.y}
         {...bind}
       >
-        <ForegroundLayer
-          url={svgUrl}
-          color="#000000"
-          size={{ type: 'scaled', factor: 0.01 }}
-        />
+        <ForegroundLayer url={svgUrl} color="#000000" size={svgSize} />
       </a.group>
     </>
   )


### PR DESCRIPTION
## Summary
- group Tweakpane controls for effect and foreground parameters
- expose SVG size dropdown with mode-specific slider
- narrow decay range and step limits
- log progress

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864b7dc735c8332bdda417c1a3f0a9d