### PR TITLE
Add bezier smoothing to frame interpolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,10 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **29** – Simplified drag release handling with a requestAnimationFrame cursor check so the cursor resets once the shape moves. Lint and build pass.
 - **30** – Refactored cursor checking to raycast against the dragged group using a shared ref; hooks accept the ref so cursor updates even when the shape moves. Lint and build pass.
 - **31** – Fixed quick-release cursor bug by starting springing state before the animation and scheduling the cursor check reliably. Lint and build pass.
+- **32** – Added bezier-style smoothing in `useFrameInterpolator`, tracking a previous pose and resetting on drag release. Updated hooks and demo. Lint and build pass.
 
 ## Next Steps
 
 - Tune random paint blending for performance and visual quality.
-- Explore path-based interpolation curves for even smoother motion.
 - Profile high-DPR rendering performance and optimize FBO sizing.
 - Expose additional shader uniforms via Tweakpane for experimentation.

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -20,13 +20,14 @@ function useSvgUrl(): string {
 export default function ForegroundLayerDemo() {
   const svgUrl = useSvgUrl()
   const dragRef = useRef<THREE.Group | null>(null)
-  const { bind, pose, active, interactionSession } = useDragAndSpring(dragRef)
+  const { bind, pose, active, interactionSession, isDragging } =
+    useDragAndSpring(dragRef)
   const [stepSize, setStepSize] = useState(20)
   const [svgSize, setSvgSize] = useState<SvgSize>({
     type: 'scaled',
     factor: 1,
   })
-  const interpQueue = useFrameInterpolator(pose, stepSize)
+  const interpQueue = useFrameInterpolator(pose, isDragging, stepSize)
   const shaderMap = {
     motionBlur: motionBlurFrag,
     randomPaint: randomPaintFrag,

--- a/src/hooks/useDragAndSpring.ts
+++ b/src/hooks/useDragAndSpring.ts
@@ -140,6 +140,7 @@ export default function useDragAndSpring(
     },
     pose: spring,
     active: isDragging || isSpringing,
+    isDragging,
     interactionSession,
   }
 }

--- a/src/hooks/useFrameInterpolator.ts
+++ b/src/hooks/useFrameInterpolator.ts
@@ -1,11 +1,12 @@
 import { useFrame, useThree } from '@react-three/fiber'
 import { SpringValue } from '@react-spring/three'
-import { useRef } from 'react'
+import { useRef, useEffect } from 'react'
 import type { MutableRefObject } from 'react'
 import type { DragSpringPose } from './useDragAndSpring'
 
 export default function useFrameInterpolator(
   pose: { x: SpringValue<number>; y: SpringValue<number> },
+  isDragging: boolean,
   stepPx = 20
 ): MutableRefObject<DragSpringPose[]> {
   const { size, viewport, gl } = useThree()
@@ -13,7 +14,14 @@ export default function useFrameInterpolator(
     x: pose.x.get(),
     y: pose.y.get(),
   })
+  const prevPose = useRef<DragSpringPose | null>(null)
   const queue = useRef<DragSpringPose[]>([])
+
+  useEffect(() => {
+    if (!isDragging) {
+      prevPose.current = null
+    }
+  }, [isDragging])
 
   useFrame(() => {
     const current = { x: pose.x.get(), y: pose.y.get() }
@@ -29,14 +37,36 @@ export default function useFrameInterpolator(
       const distPx = Math.sqrt(dxPx * dxPx + dyPx * dyPx)
       const steps = Math.max(1, Math.ceil(distPx / stepPx))
 
-      for (let i = 1; i <= steps; i++) {
-        const t = i / steps
-        queue.current.push({
-          x: lastPose.current.x + dx * t,
-          y: lastPose.current.y + dy * t,
-        })
+      if (prevPose.current) {
+        const cp = {
+          x: lastPose.current.x + 0.25 * (current.x - prevPose.current.x),
+          y: lastPose.current.y + 0.25 * (current.y - prevPose.current.y),
+        }
+        for (let i = 1; i <= steps; i++) {
+          const t = i / steps
+          const omt = 1 - t
+          queue.current.push({
+            x:
+              omt * omt * lastPose.current.x +
+              2 * omt * t * cp.x +
+              t * t * current.x,
+            y:
+              omt * omt * lastPose.current.y +
+              2 * omt * t * cp.y +
+              t * t * current.y,
+          })
+        }
+      } else {
+        for (let i = 1; i <= steps; i++) {
+          const t = i / steps
+          queue.current.push({
+            x: lastPose.current.x + dx * t,
+            y: lastPose.current.y + dy * t,
+          })
+        }
       }
 
+      prevPose.current = { ...lastPose.current }
       lastPose.current = current
     }
   })


### PR DESCRIPTION
## Summary
- smooth interpolation curve using previous pose as bezier guide
- expose `isDragging` from `useDragAndSpring`
- wire new param into `ForegroundLayerDemo`
- log progress in AGENTS

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686581e3f51c8332bb4596a5950464a1