### PR TITLE
Add preprocess shader options and motion-based snapshots

### DIFF
--- a/src/shaders/boxBlur.frag
+++ b/src/shaders/boxBlur.frag
@@ -1,0 +1,20 @@
+precision highp float;
+
+varying vec2 vUv;
+uniform sampler2D uTexture;
+uniform vec2 uTexelSize;
+uniform float uRadius;
+
+void main() {
+  vec2 off = uTexelSize * uRadius;
+  vec4 sum = texture2D(uTexture, vUv + off * vec2(-1.0, -1.0));
+  sum += texture2D(uTexture, vUv + off * vec2(0.0, -1.0));
+  sum += texture2D(uTexture, vUv + off * vec2(1.0, -1.0));
+  sum += texture2D(uTexture, vUv + off * vec2(-1.0, 0.0));
+  sum += texture2D(uTexture, vUv);
+  sum += texture2D(uTexture, vUv + off * vec2(1.0, 0.0));
+  sum += texture2D(uTexture, vUv + off * vec2(-1.0, 1.0));
+  sum += texture2D(uTexture, vUv + off * vec2(0.0, 1.0));
+  sum += texture2D(uTexture, vUv + off * vec2(1.0, 1.0));
+  gl_FragColor = sum / 9.0;
+}

--- a/src/shaders/gaussianBlur.frag
+++ b/src/shaders/gaussianBlur.frag
@@ -1,0 +1,21 @@
+precision highp float;
+
+varying vec2 vUv;
+uniform sampler2D uTexture;
+uniform vec2 uTexelSize;
+uniform float uRadius;
+
+void main() {
+  vec2 off = uTexelSize * uRadius;
+  vec4 sum = vec4(0.0);
+  sum += texture2D(uTexture, vUv + off * vec2(-1.0, -1.0)) * 1.0;
+  sum += texture2D(uTexture, vUv + off * vec2(0.0, -1.0)) * 2.0;
+  sum += texture2D(uTexture, vUv + off * vec2(1.0, -1.0)) * 1.0;
+  sum += texture2D(uTexture, vUv + off * vec2(-1.0, 0.0)) * 2.0;
+  sum += texture2D(uTexture, vUv) * 4.0;
+  sum += texture2D(uTexture, vUv + off * vec2(1.0, 0.0)) * 2.0;
+  sum += texture2D(uTexture, vUv + off * vec2(-1.0, 1.0)) * 1.0;
+  sum += texture2D(uTexture, vUv + off * vec2(0.0, 1.0)) * 2.0;
+  sum += texture2D(uTexture, vUv + off * vec2(1.0, 1.0)) * 1.0;
+  gl_FragColor = sum / 16.0;
+}


### PR DESCRIPTION
## Summary
- add blur preprocess shader selections including a new gaussian blur
- snapshot capture now runs only when the foreground moves
- convert blur toggle to preprocess dropdown in Tweakpane

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865b9af4bcc83329edfe260771a0167