### PR TITLE
Fix random paint blending with blur

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **35** – Replaced `addInput` with `addBinding` for the blur toggle to match Tweakpane v4 API and updated state syncing. Lint and build pass.
 - **36** – Updated `randomPaint.frag` to blend snapshot alpha with history so blurred edges accumulate correctly. Lint and build pass.
 - **37** – Switched `randomPaint.frag` to premultiplied alpha blending to remove dark edges. Lint and build pass.
+- **38** – Revised `randomPaint.frag` to use alpha compositing with decay, preventing color blowout and keeping edges smooth. Lint and build pass.
 
 ## Next Steps
 

--- a/src/shaders/randomPaint.frag
+++ b/src/shaders/randomPaint.frag
@@ -8,15 +8,15 @@ uniform vec3 uSessionRandom;
 
 void main() {
   vec4 history = texture2D(uPrevFrame, vUv);
-  float mask = texture2D(uSnapshot, vUv).a;
+  float oldAlpha = history.a * uDecay;
+  vec3 oldColor = history.rgb;
 
-  // Accumulate using premultiplied alpha to avoid dark fringes
-  vec3 historyPremul = history.rgb * history.a * uDecay;
-  vec3 newPremul = uSessionRandom * mask;
+  float newAlpha = texture2D(uSnapshot, vUv).a;
+  vec3 newColor = uSessionRandom;
 
-  float alpha = clamp(history.a * uDecay + mask, 0.0, 1.0);
-  vec3 accum = historyPremul + newPremul;
-  vec3 color = alpha > 0.0 ? accum / alpha : vec3(0.0);
+  float outAlpha = newAlpha + oldAlpha * (1.0 - newAlpha);
+  vec3 outColor = (newColor * newAlpha + oldColor * oldAlpha * (1.0 - newAlpha)) /
+                  max(outAlpha, 1e-5);
 
-  gl_FragColor = vec4(color, alpha);
+  gl_FragColor = vec4(outColor, outAlpha);
 }


### PR DESCRIPTION
## Summary
- blend `randomPaint.frag` with snapshot alpha so blurred edges accumulate
- log progress

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865c0a44e148332ae1b3e2cf5aa074b