### PR TITLE
Add text foreground option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **38** – Revised `randomPaint.frag` to use alpha compositing with decay, preventing color blowout and keeping edges smooth. Lint and build pass.
 - **39** – Refactored `ForegroundLayer` into `SvgMesh`, extracted `DraggableSvg` and `DemoControls` components, and updated README. Lint and build pass.
 
+- **40** – Added text foreground option with tweakpane controls and new `TextMesh`. Updated demo to choose between diamond SVG and custom text. Lint and build pass.
+
 ## Next Steps
 
 - Tune random paint blending for performance and visual quality.

--- a/src/components/DemoControls.tsx
+++ b/src/components/DemoControls.tsx
@@ -13,6 +13,10 @@ export type DemoControlsProps = {
   setPreprocessName: (name: string) => void
   svgSize: SvgSize
   setSvgSize: (size: SvgSize) => void
+  sourceName: 'diamond' | 'text'
+  setSourceName: (name: 'diamond' | 'text') => void
+  textValue: string
+  setTextValue: (val: string) => void
 }
 
 export default function DemoControls({
@@ -26,6 +30,10 @@ export default function DemoControls({
   setPreprocessName,
   svgSize,
   setSvgSize,
+  sourceName,
+  setSourceName,
+  textValue,
+  setTextValue,
 }: DemoControlsProps) {
   useEffect(() => {
     const pane = new Pane()
@@ -33,6 +41,45 @@ export default function DemoControls({
     const effectFolder = (pane as any).addFolder({ title: 'Effect' })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const fgFolder = (pane as any).addFolder({ title: 'Foreground' })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sourceInput = (fgFolder as any).addBlade({
+      view: 'list',
+      label: 'source',
+      options: [
+        { text: 'Diamond', value: 'diamond' },
+        { text: 'Text', value: 'text' },
+      ],
+      value: sourceName,
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let textBlade: any
+    const updateTextBlade = (type: 'diamond' | 'text') => {
+      if (textBlade) fgFolder.remove(textBlade)
+      if (type === 'text') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        textBlade = (fgFolder as any).addBlade({
+          view: 'text',
+          label: 'text',
+          parse: (v: unknown) => String(v),
+          value: textValue,
+        })
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        textBlade.on('change', (ev: any) => setTextValue(ev.value))
+      } else {
+        textBlade = undefined
+      }
+    }
+
+    updateTextBlade(sourceName)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sourceInput.on('change', (ev: any) => {
+      const val = ev.value as 'diamond' | 'text'
+      setSourceName(val)
+      updateTextBlade(val)
+    })
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const shaderInput = (effectFolder as any).addBlade({

--- a/src/components/DraggableForeground.tsx
+++ b/src/components/DraggableForeground.tsx
@@ -6,10 +6,12 @@ import useFrameInterpolator from '../hooks/useFrameInterpolator'
 import useFeedbackFBO from '../hooks/useFeedbackFBO'
 import FeedbackPlane from './FeedbackPlane'
 import SvgMesh from './SvgMesh'
+import TextMesh from './TextMesh'
 import type { SvgSize } from '../types/svg'
+import type { ForegroundContent } from '../types/foreground'
 
-export type DraggableSvgProps = {
-  svgUrl: string
+export type DraggableForegroundProps = {
+  content: ForegroundContent
   shader: string
   decay: number
   stepSize: number
@@ -17,14 +19,14 @@ export type DraggableSvgProps = {
   svgSize: SvgSize
 }
 
-export default function DraggableSvg({
-  svgUrl,
+export default function DraggableForeground({
+  content,
   shader,
   decay,
   stepSize,
   preprocessShader,
   svgSize,
-}: DraggableSvgProps) {
+}: DraggableForegroundProps) {
   const dragRef = useRef<THREE.Group | null>(null)
   const { bind, pose, active, interactionSession, isDragging } =
     useDragAndSpring(dragRef)
@@ -49,7 +51,11 @@ export default function DraggableSvg({
         position-y={pose.y}
         {...bind}
       >
-        <SvgMesh url={svgUrl} color="#000000" size={svgSize} />
+        {content.kind === 'svg' ? (
+          <SvgMesh url={content.url} color="#000000" size={svgSize} />
+        ) : (
+          <TextMesh text={content.text} color="#000000" size={svgSize} />
+        )}
       </a.group>
     </>
   )

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 import defaultSvgUrl from '../assets/diamond.svg?url'
-import DraggableSvg from './DraggableSvg'
+import DraggableForeground from './DraggableForeground'
 import DemoControls from './DemoControls'
 import motionBlurFrag from '../shaders/motionBlur.frag'
 import randomPaintFrag from '../shaders/randomPaint.frag'
 import boxBlurFrag from '../shaders/boxBlur.frag'
 import gaussianBlurFrag from '../shaders/gaussianBlur.frag'
 import type { SvgSize } from '../types/svg'
+import type { ForegroundContent } from '../types/foreground'
 
 function useSvgUrl(): string {
   const params = new URLSearchParams(window.location.search)
@@ -27,6 +28,8 @@ export default function ForegroundLayerDemo() {
     type: 'scaled',
     factor: 1,
   })
+  const [sourceName, setSourceName] = useState<'diamond' | 'text'>('diamond')
+  const [textValue, setTextValue] = useState('Hello World')
   const shaderMap = {
     motionBlur: motionBlurFrag,
     randomPaint: randomPaintFrag,
@@ -34,6 +37,11 @@ export default function ForegroundLayerDemo() {
   const [shaderName, setShaderName] =
     useState<keyof typeof shaderMap>('motionBlur')
   const [decay, setDecay] = useState(0.9)
+
+  const content: ForegroundContent =
+    sourceName === 'text'
+      ? { kind: 'text', text: textValue }
+      : { kind: 'svg', url: svgUrl }
 
   return (
     <>
@@ -50,9 +58,13 @@ export default function ForegroundLayerDemo() {
         }
         svgSize={svgSize}
         setSvgSize={setSvgSize}
+        sourceName={sourceName}
+        setSourceName={(n) => setSourceName(n as 'diamond' | 'text')}
+        textValue={textValue}
+        setTextValue={setTextValue}
       />
-      <DraggableSvg
-        svgUrl={svgUrl}
+      <DraggableForeground
+        content={content}
         shader={shaderMap[shaderName]}
         decay={decay}
         stepSize={stepSize}

--- a/src/components/TextMesh.tsx
+++ b/src/components/TextMesh.tsx
@@ -1,0 +1,67 @@
+import { Text } from '@react-three/drei'
+import { useThree } from '@react-three/fiber'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import * as THREE from 'three'
+import type { SvgSize } from '../types/svg'
+
+export type TextMeshProps = {
+  text: string
+  color?: string
+  size?: SvgSize
+}
+
+export default function TextMesh({
+  text,
+  color = '#ffffff',
+  size = { type: 'scaled', factor: 1 },
+}: TextMeshProps) {
+  const depth = 0.1
+  const { viewport, camera, size: viewportSize } = useThree()
+  const current = viewport.getCurrentViewport(camera, [0, 0, depth])
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const textRef = useRef<any>(null)
+  const [bounds, setBounds] = useState<THREE.Box3 | null>(null)
+
+  useEffect(() => {
+    const troika = textRef.current
+    if (troika) {
+      troika.sync(() => {
+        const box = new THREE.Box3().setFromObject(troika)
+        setBounds(box)
+      })
+    }
+  }, [text])
+
+  const pixelScale = useMemo(() => {
+    const factorX = current.width / viewportSize.width
+    const factorY = current.height / viewportSize.height
+    return Math.min(factorX, factorY)
+  }, [current.width, current.height, viewportSize.width, viewportSize.height])
+
+  const nativeWidth = bounds ? bounds.max.x - bounds.min.x : 1
+  const nativeHeight = bounds ? bounds.max.y - bounds.min.y : 1
+
+  const scale = useMemo(() => {
+    switch (size.type) {
+      case 'natural':
+        return pixelScale
+      case 'scaled':
+        return pixelScale * size.factor
+      case 'relative': {
+        const base = Math.min(current.width, current.height)
+        const largest = Math.max(nativeWidth, nativeHeight)
+        return (size.fraction * base) / largest
+      }
+    }
+  }, [size, pixelScale, current.width, current.height, nativeWidth, nativeHeight])
+
+  const position: [number, number, number] = [0, 0, depth]
+
+  return (
+    <group scale={scale} position={position}>
+      <Text ref={textRef} fontSize={24} color={color} anchorX="center" anchorY="middle">
+        {text}
+      </Text>
+    </group>
+  )
+}

--- a/src/types/foreground.ts
+++ b/src/types/foreground.ts
@@ -1,0 +1,3 @@
+export type ForegroundContent =
+  | { kind: 'svg'; url: string }
+  | { kind: 'text'; text: string }


### PR DESCRIPTION
## Summary
- support both SVGs and text for the draggable foreground layer
- add TextMesh component for rendering typed text
- expose `source` and `text` controls in DemoControls
- update the demo to choose between diamond SVG and typed text

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865cf6ce1b48332ba222c4e27d9130e