### PR TITLE
Use General Sans for text and expose font setting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,11 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 
 - **40** – Added text foreground option with tweakpane controls and new `TextMesh`. Updated demo to choose between diamond SVG and custom text. Lint and build pass.
 
+- **41** – Integrated General Sans font for text meshes with new Tweakpane font field and updated layout. Default text size doubled to 48pt. Lint warns on hooks; build succeeds.
+
 ## Next Steps
 
 - Tune random paint blending for performance and visual quality.
 - Profile high-DPR rendering performance and optimize FBO sizing.
 - Expose additional shader uniforms via Tweakpane for experimentation.
+- Add more font options and styling controls for text mode.

--- a/src/components/DemoControls.tsx
+++ b/src/components/DemoControls.tsx
@@ -17,6 +17,8 @@ export type DemoControlsProps = {
   setSourceName: (name: 'diamond' | 'text') => void
   textValue: string
   setTextValue: (val: string) => void
+  fontUrl: string
+  setFontUrl: (val: string) => void
 }
 
 export default function DemoControls({
@@ -34,6 +36,8 @@ export default function DemoControls({
   setSourceName,
   textValue,
   setTextValue,
+  fontUrl,
+  setFontUrl,
 }: DemoControlsProps) {
   useEffect(() => {
     const pane = new Pane()
@@ -52,6 +56,16 @@ export default function DemoControls({
       ],
       value: sourceName,
     })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fontInput = (fgFolder as any).addBlade({
+      view: 'text',
+      label: 'font',
+      parse: (v: unknown) => String(v),
+      value: fontUrl,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fontInput.on('change', (ev: any) => setFontUrl(ev.value))
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let textBlade: any

--- a/src/components/DraggableForeground.tsx
+++ b/src/components/DraggableForeground.tsx
@@ -17,6 +17,7 @@ export type DraggableForegroundProps = {
   stepSize: number
   preprocessShader: string | null
   svgSize: SvgSize
+  fontUrl: string
 }
 
 export default function DraggableForeground({
@@ -26,6 +27,7 @@ export default function DraggableForeground({
   stepSize,
   preprocessShader,
   svgSize,
+  fontUrl,
 }: DraggableForegroundProps) {
   const dragRef = useRef<THREE.Group | null>(null)
   const { bind, pose, active, interactionSession, isDragging } =
@@ -54,7 +56,12 @@ export default function DraggableForeground({
         {content.kind === 'svg' ? (
           <SvgMesh url={content.url} color="#000000" size={svgSize} />
         ) : (
-          <TextMesh text={content.text} color="#000000" size={svgSize} />
+          <TextMesh
+            text={content.text}
+            color="#000000"
+            size={svgSize}
+            fontUrl={fontUrl}
+          />
         )}
       </a.group>
     </>

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import defaultSvgUrl from '../assets/diamond.svg?url'
+import defaultFontUrl from '../assets/GeneralSans-Bold.woff2?url'
 import DraggableForeground from './DraggableForeground'
 import DemoControls from './DemoControls'
 import motionBlurFrag from '../shaders/motionBlur.frag'
@@ -30,6 +31,7 @@ export default function ForegroundLayerDemo() {
   })
   const [sourceName, setSourceName] = useState<'diamond' | 'text'>('diamond')
   const [textValue, setTextValue] = useState('Hello World')
+  const [fontUrl, setFontUrl] = useState(defaultFontUrl)
   const shaderMap = {
     motionBlur: motionBlurFrag,
     randomPaint: randomPaintFrag,
@@ -62,6 +64,8 @@ export default function ForegroundLayerDemo() {
         setSourceName={(n) => setSourceName(n as 'diamond' | 'text')}
         textValue={textValue}
         setTextValue={setTextValue}
+        fontUrl={fontUrl}
+        setFontUrl={setFontUrl}
       />
       <DraggableForeground
         content={content}
@@ -70,6 +74,7 @@ export default function ForegroundLayerDemo() {
         stepSize={stepSize}
         preprocessShader={preprocessMap[preprocessName]}
         svgSize={svgSize}
+        fontUrl={fontUrl}
       />
     </>
   )

--- a/src/components/TextMesh.tsx
+++ b/src/components/TextMesh.tsx
@@ -2,18 +2,21 @@ import { Text } from '@react-three/drei'
 import { useThree } from '@react-three/fiber'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
+import generalSansUrl from '../assets/GeneralSans-Bold.woff2?url'
 import type { SvgSize } from '../types/svg'
 
 export type TextMeshProps = {
   text: string
   color?: string
   size?: SvgSize
+  fontUrl?: string
 }
 
 export default function TextMesh({
   text,
   color = '#ffffff',
   size = { type: 'scaled', factor: 1 },
+  fontUrl = generalSansUrl,
 }: TextMeshProps) {
   const depth = 0.1
   const { viewport, camera, size: viewportSize } = useThree()
@@ -30,7 +33,7 @@ export default function TextMesh({
         setBounds(box)
       })
     }
-  }, [text])
+  }, [text, fontUrl])
 
   const pixelScale = useMemo(() => {
     const factorX = current.width / viewportSize.width
@@ -59,7 +62,14 @@ export default function TextMesh({
 
   return (
     <group scale={scale} position={position}>
-      <Text ref={textRef} fontSize={24} color={color} anchorX="center" anchorY="middle">
+      <Text
+        ref={textRef}
+        fontSize={48}
+        font={fontUrl}
+        color={color}
+        anchorX="center"
+        anchorY="middle"
+      >
         {text}
       </Text>
     </group>


### PR DESCRIPTION
## Summary
- integrate GeneralSans-Bold.woff2 as the default font for text rendering
- add a font URL control in DemoControls and place it under the source selector
- keep the text entry right below the font field when text is selected
- double the base text size to 48pt
- document progress in AGENTS log

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866059b13b48332a6b69fec1e67f7bc