### PR TITLE
Fix text relative sizing and update log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,10 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 
 - **40** – Added text foreground option with tweakpane controls and new `TextMesh`. Updated demo to choose between diamond SVG and custom text. Lint and build pass.
 
+- **41** – Reorganized Tweakpane controls with a new "Foreground Sizing" section, moved preprocess under "Foreground", and fixed text relative sizing by computing bounds from unscaled geometry. Lint warns on hooks; build succeeds.
+- **42** – Updated text bounds to use `textRenderInfo.blockBounds` so relative sizing scales correctly. Lint warns on hooks; build succeeds.
+- **43** – Switched text bounds to `visibleBounds` for more accurate sizing when using relative mode. Lint warns on hooks; build succeeds.
+
 ## Next Steps
 
 - Tune random paint blending for performance and visual quality.

--- a/src/components/DemoControls.tsx
+++ b/src/components/DemoControls.tsx
@@ -41,6 +41,22 @@ export default function DemoControls({
     const effectFolder = (pane as any).addFolder({ title: 'Effect' })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const fgFolder = (pane as any).addFolder({ title: 'Foreground' })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sizeFolder = (pane as any).addFolder({ title: 'Foreground Sizing' })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const preprocessInput = (fgFolder as any).addBlade({
+      view: 'list',
+      label: 'preprocess',
+      options: [
+        { text: 'None', value: 'none' },
+        { text: 'Box Blur', value: 'box' },
+        { text: 'Gaussian Blur', value: 'gaussian' },
+      ],
+      value: preprocessName,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    preprocessInput.on('change', (ev: any) => setPreprocessName(ev.value))
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sourceInput = (fgFolder as any).addBlade({
@@ -118,21 +134,7 @@ export default function DemoControls({
     interpInput.on('change', (ev: any) => setStepSize(ev.value))
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const preprocessInput = (effectFolder as any).addBlade({
-      view: 'list',
-      label: 'preprocess',
-      options: [
-        { text: 'None', value: 'none' },
-        { text: 'Box Blur', value: 'box' },
-        { text: 'Gaussian Blur', value: 'gaussian' },
-      ],
-      value: preprocessName,
-    })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    preprocessInput.on('change', (ev: any) => setPreprocessName(ev.value))
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sizeInput = (fgFolder as any).addBlade({
+    const sizeInput = (sizeFolder as any).addBlade({
       view: 'list',
       label: 'size',
       options: [
@@ -146,10 +148,10 @@ export default function DemoControls({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let paramBlade: any
     const updateParamBlade = (type: SvgSize['type']) => {
-      if (paramBlade) fgFolder.remove(paramBlade)
+      if (paramBlade) sizeFolder.remove(paramBlade)
       if (type === 'scaled') {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        paramBlade = (fgFolder as any).addBlade({
+        paramBlade = (sizeFolder as any).addBlade({
           view: 'slider',
           label: 'factor',
           min: 0,
@@ -162,7 +164,7 @@ export default function DemoControls({
         )
       } else if (type === 'relative') {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        paramBlade = (fgFolder as any).addBlade({
+        paramBlade = (sizeFolder as any).addBlade({
           view: 'slider',
           label: 'fraction',
           min: 0,

--- a/src/components/TextMesh.tsx
+++ b/src/components/TextMesh.tsx
@@ -26,8 +26,19 @@ export default function TextMesh({
     const troika = textRef.current
     if (troika) {
       troika.sync(() => {
-        const box = new THREE.Box3().setFromObject(troika)
-        setBounds(box)
+        // `Text` computes layout asynchronously; pull bounds from
+        // `textRenderInfo` once it's ready so sizing works reliably.
+        // `visibleBounds` tightly wraps the glyph shapes and avoids
+        // extra padding from `lineHeight` or anchoring offsets.
+        if (troika.textRenderInfo && troika.textRenderInfo.visibleBounds) {
+          const [minX, minY, maxX, maxY] = troika.textRenderInfo.visibleBounds
+          setBounds(
+            new THREE.Box3(
+              new THREE.Vector3(minX, minY, 0),
+              new THREE.Vector3(maxX, maxY, 0)
+            )
+          )
+        }
       })
     }
   }, [text])


### PR DESCRIPTION
## Summary
- switch `TextMesh` bounds to use `visibleBounds` for reliable scaling
- document the change in AGENTS log

## Testing
- `npm run lint` *(with warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68660ae88c20833289199e27023b196c