### PR TITLE
Disable relative size mode for text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **43** – Retrieved text bounds from the generated geometry to further fix relative sizing. Lint warns on hooks; build succeeds.
 - **44** – Calculated text bounds from `visibleBounds` scaled by `fontSize` and added console logging for debugging. Lint warns on hooks; build succeeds.
 - **45** – Investigated text sizing further; troika-three-text metrics use font units and don't map cleanly to viewport pixels. Concluded reliable relative sizing isn't feasible without major redesign. Lint and build pass.
+- **46** – Disabled 'relative' size mode when text source is active; Tweakpane now hides the option and reverts to scaled. Lint and build pass.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- disable the relative sizing option when the text source is active
- automatically reset relative sizing to scaled if needed

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68661537cc508332a0c99ee8a211c89d