### PR TITLE
Use half-float render targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **45** – Investigated text sizing further; troika-three-text metrics use font units and don't map cleanly to viewport pixels. Concluded reliable relative sizing isn't feasible without major redesign. Lint and build pass.
 - **46** – Disabled 'relative' size mode when text source is active; Tweakpane now hides the option and reverts to scaled. Lint and build pass.
 
+- **47** – Allocated feedback render targets with `HalfFloatType` to eliminate residual trails at high decay. Lint and build pass.
+
 ## Next Steps
 
 - Tune random paint blending for performance and visual quality.

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -35,16 +35,24 @@ export default function useFeedbackFBO(
   )
 
   const readRT = useRef(
-    new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr)
+    new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr, {
+      type: THREE.HalfFloatType,
+    })
   )
   const writeRT = useRef(
-    new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr)
+    new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr, {
+      type: THREE.HalfFloatType,
+    })
   )
   const snapshotRT = useRef(
-    new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr)
+    new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr, {
+      type: THREE.HalfFloatType,
+    })
   )
   const preprocessRT = useRef(
-    new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr)
+    new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr, {
+      type: THREE.HalfFloatType,
+    })
   )
 
   const preprocessUniforms = useMemo(


### PR DESCRIPTION
## Summary
- allocate feedback buffers with `HalfFloatType`
- note this improvement in AGENTS log

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686617ea2ca883329fd85a46a73bd625