### PR TITLE
Add time uniform for shaders and ripple fade warp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 
 - **47** – Allocated feedback render targets with `HalfFloatType` to eliminate residual trails at high decay. Lint and build pass.
 
+- **48** – Added `uTime` uniform in `useFeedbackFBO` and implemented noise-driven warp in `rippleFade.frag`. Lint and build pass.
+
 ## Next Steps
 
 - Tune random paint and ripple fade blending for performance and visual quality.

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -34,6 +34,8 @@ export default function useFeedbackFBO(
     new THREE.Vector3(Math.random(), Math.random(), Math.random())
   )
 
+  const timeRef = useRef(0)
+
   const readRT = useRef(
     new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr, {
       type: THREE.HalfFloatType,
@@ -91,6 +93,7 @@ export default function useFeedbackFBO(
       uSnapshot: { value: snapshotRT.current.texture },
       uDecay: { value: decay },
       uSessionRandom: { value: sessionRandom.current.clone() },
+      uTime: { value: 0 },
     }),
     [decay]
   )
@@ -143,7 +146,9 @@ export default function useFeedbackFBO(
     }
   }, [])
 
-  useFrame(() => {
+  useFrame((state) => {
+    timeRef.current = state.clock.getElapsedTime()
+    uniforms.uTime.value = timeRef.current
     // Prepare snapshot texture
     gl.setRenderTarget(snapshotRT.current)
     gl.setClearColor(0x000000, 0)

--- a/src/shaders/rippleFade.frag
+++ b/src/shaders/rippleFade.frag
@@ -4,9 +4,26 @@ varying vec2 vUv;
 uniform sampler2D uPrevFrame;
 uniform sampler2D uSnapshot;
 uniform float uDecay;
+uniform float uTime;
+
+float random(vec2 st){
+  return fract(sin(dot(st, vec2(12.9898,78.233))) * 43758.5453123);
+}
+
+float noise(vec2 st){
+  vec2 i = floor(st);
+  vec2 f = fract(st);
+  vec2 u = f * f * (3.0 - 2.0 * f);
+  return mix(mix(random(i), random(i + vec2(1.0, 0.0)), u.x),
+             mix(random(i + vec2(0.0, 1.0)), random(i + vec2(1.0, 1.0)), u.x),
+             u.y);
+}
 
 void main(){
-    vec4 history=texture2D(uPrevFrame,vUv);
+    vec2 uv=vUv;
+    float n=noise(uv*4.0+uTime*0.5);
+    uv+= (n-0.5)*0.05;
+    vec4 history=texture2D(uPrevFrame,uv)*uDecay;
     vec4 snap=texture2D(uSnapshot,vUv);
-    gl_FragColor=history*uDecay+snap;
+    gl_FragColor=history+snap;
 }


### PR DESCRIPTION
## Summary
- allow shaders to access elapsed time via new `uTime` uniform
- modulate `rippleFade.frag` feedback using a time-driven noise warp

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869f7dd8ffc8332a4bfcd45cea25b90