### PR TITLE
Add tweakpane background selector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **47** – Added `rippleFade.frag` shader to effect dropdown and updated shader map in demo. Lint and build pass.
 
 - **47** – Allocated feedback render targets with `HalfFloatType` to eliminate residual trails at high decay. Lint and build pass.
+- **48** – Added background chooser (wildflowers or white) in Tweakpane and threaded state through components. Lint and build pass.
 
 ## Next Steps
 
@@ -70,3 +71,4 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - Profile high-DPR rendering performance and optimize FBO sizing.
 - Expose additional shader uniforms via Tweakpane for experimentation.
 - Consider alternate text display since reliable relative sizing is not feasible.
+- Add more background images and color options to the new selector.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,25 @@
 import CanvasStage from './components/CanvasStage'
 import './App.css'
-import defaultBgUrl from './assets/wildflowers.png'
+import wildflowersUrl from './assets/wildflowers.png'
+import { useState } from 'react'
 
-function useBackgroundUrl(): string {
+function useInitialBgName(): 'wildflowers' | 'white' {
   const params = new URLSearchParams(window.location.search)
-  return params.get('bg') || defaultBgUrl
+  return (params.get('bg') as 'wildflowers' | 'white') || 'wildflowers'
 }
 
 export default function App() {
-  const bgUrl = useBackgroundUrl()
+  const [bgName, setBgName] = useState<'wildflowers' | 'white'>(useInitialBgName)
+  const style =
+    bgName === 'wildflowers'
+      ? { backgroundImage: `url(${wildflowersUrl})` }
+      : { backgroundColor: '#ffffff' }
   return (
     <div
       className="w-screen h-screen overflow-hidden bg-cover bg-center"
-      style={{ backgroundImage: `url(${bgUrl})` }}
+      style={style}
     >
-      <CanvasStage />
+      <CanvasStage backgroundName={bgName} setBackgroundName={setBgName} />
     </div>
   )
 }

--- a/src/components/CanvasStage.tsx
+++ b/src/components/CanvasStage.tsx
@@ -2,11 +2,22 @@ import { Canvas } from '@react-three/fiber'
 import { Suspense } from 'react'
 import ForegroundLayerDemo from './ForegroundLayerDemo'
 
-export default function CanvasStage() {
+export type CanvasStageProps = {
+  backgroundName: 'wildflowers' | 'white'
+  setBackgroundName: (name: 'wildflowers' | 'white') => void
+}
+
+export default function CanvasStage({
+  backgroundName,
+  setBackgroundName,
+}: CanvasStageProps) {
   return (
     <Canvas className="w-full h-full">
       <Suspense fallback={null}>
-        <ForegroundLayerDemo />
+        <ForegroundLayerDemo
+          backgroundName={backgroundName}
+          setBackgroundName={setBackgroundName}
+        />
       </Suspense>
     </Canvas>
   )

--- a/src/components/DemoControls.tsx
+++ b/src/components/DemoControls.tsx
@@ -3,6 +3,8 @@ import { Pane } from 'tweakpane'
 import type { SvgSize } from '../types/svg'
 
 export type DemoControlsProps = {
+  backgroundName: 'wildflowers' | 'white'
+  setBackgroundName: (name: 'wildflowers' | 'white') => void
   shaderName: string
   setShaderName: (name: string) => void
   decay: number
@@ -20,6 +22,8 @@ export type DemoControlsProps = {
 }
 
 export default function DemoControls({
+  backgroundName,
+  setBackgroundName,
   shaderName,
   setShaderName,
   decay,
@@ -48,6 +52,20 @@ export default function DemoControls({
     const sizeFolder = (pane as any).addFolder({ title: 'Foreground Sizing' })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const effectFolder = (pane as any).addFolder({ title: 'Effect' })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const bgFolder = (pane as any).addFolder({ title: 'Background' })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const bgInput = (bgFolder as any).addBlade({
+      view: 'list',
+      label: 'image',
+      options: [
+        { text: 'Wildflowers', value: 'wildflowers' },
+        { text: 'White', value: 'white' },
+      ],
+      value: backgroundName,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    bgInput.on('change', (ev: any) => setBackgroundName(ev.value))
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const preprocessInput = (fgFolder as any).addBlade({

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -15,7 +15,15 @@ function useSvgUrl(): string {
   return params.get('svg') || defaultSvgUrl
 }
 
-export default function ForegroundLayerDemo() {
+export type ForegroundLayerDemoProps = {
+  backgroundName: 'wildflowers' | 'white'
+  setBackgroundName: (name: 'wildflowers' | 'white') => void
+}
+
+export default function ForegroundLayerDemo({
+  backgroundName,
+  setBackgroundName,
+}: ForegroundLayerDemoProps) {
   const svgUrl = useSvgUrl()
   const [stepSize, setStepSize] = useState(2)
   const preprocessMap = {
@@ -48,6 +56,8 @@ export default function ForegroundLayerDemo() {
   return (
     <>
       <DemoControls
+        backgroundName={backgroundName}
+        setBackgroundName={setBackgroundName}
         shaderName={shaderName}
         setShaderName={(n) => setShaderName(n as keyof typeof shaderMap)}
         decay={decay}


### PR DESCRIPTION
## Summary
- keep `App` background in state so it can be updated at runtime
- thread background name through `CanvasStage` and `ForegroundLayerDemo`
- add a new Background folder in `DemoControls`
- update AGENTS log

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869f88ec2488332a1d78d9ae3f5f23a