### PR TITLE
Add Perlin noise offset to ripple fade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **48** – Added `uTime` uniform in `useFeedbackFBO` and implemented noise-driven warp in `rippleFade.frag`. Lint and build pass.
 - **49** – Added "paint while still" option with Tweakpane checkbox to control snapshot painting at rest. Lint and build pass.
 - **50** – Fixed "paint while still" checkbox using `addBinding` so it renders correctly. Lint and build pass.
+- **51** – Added Perlin-noise offset to `rippleFade.frag` with tweakable speed and size; new sliders wired through `DemoControls` and `useFeedbackFBO`.
 
 ## Next Steps
 

--- a/src/components/DemoControls.tsx
+++ b/src/components/DemoControls.tsx
@@ -11,6 +11,10 @@ export type DemoControlsProps = {
   setDecay: (val: number) => void
   stepSize: number
   setStepSize: (val: number) => void
+  noiseSpeed: number
+  setNoiseSpeed: (val: number) => void
+  noiseSize: number
+  setNoiseSize: (val: number) => void
   preprocessName: string
   setPreprocessName: (name: string) => void
   svgSize: SvgSize
@@ -32,6 +36,10 @@ export default function DemoControls({
   setDecay,
   stepSize,
   setStepSize,
+  noiseSpeed,
+  setNoiseSpeed,
+  noiseSize,
+  setNoiseSize,
   preprocessName,
   setPreprocessName,
   svgSize,
@@ -175,6 +183,30 @@ export default function DemoControls({
     interpInput.on('change', (ev: any) => setStepSize(ev.value))
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const speedInput = (effectFolder as any).addBlade({
+      view: 'slider',
+      label: 'noise speed',
+      min: 0,
+      max: 5,
+      value: noiseSpeed,
+      step: 0.01,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    speedInput.on('change', (ev: any) => setNoiseSpeed(ev.value))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sizeInputNoise = (effectFolder as any).addBlade({
+      view: 'slider',
+      label: 'noise size',
+      min: 0,
+      max: 0.2,
+      value: noiseSize,
+      step: 0.001,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sizeInputNoise.on('change', (ev: any) => setNoiseSize(ev.value))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let sizeInput: any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let paramBlade: any
@@ -188,7 +220,7 @@ export default function DemoControls({
           min: 0,
           max: 5,
           value: sizeRef.current.type === 'scaled' ? sizeRef.current.factor : 1,
-          step: 0.01
+          step: 0.01,
         })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         paramBlade.on('change', (ev: any) =>
@@ -205,7 +237,7 @@ export default function DemoControls({
             sizeRef.current.type === 'relative'
               ? sizeRef.current.fraction
               : 0.5,
-          step: 0.01
+          step: 0.01,
         })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         paramBlade.on('change', (ev: any) =>

--- a/src/components/DraggableForeground.tsx
+++ b/src/components/DraggableForeground.tsx
@@ -18,6 +18,8 @@ export type DraggableForegroundProps = {
   preprocessShader: string | null
   svgSize: SvgSize
   paintWhileStill: boolean
+  noiseSpeed: number
+  noiseSize: number
 }
 
 export default function DraggableForeground({
@@ -28,6 +30,8 @@ export default function DraggableForeground({
   preprocessShader,
   svgSize,
   paintWhileStill,
+  noiseSpeed,
+  noiseSize,
 }: DraggableForegroundProps) {
   const dragRef = useRef<THREE.Group | null>(null)
   const { bind, pose, active, interactionSession, isDragging } =
@@ -41,7 +45,9 @@ export default function DraggableForeground({
     interpQueue,
     dragRef,
     preprocessShader,
-    stepSize
+    stepSize,
+    noiseSpeed,
+    noiseSize
   )
 
   return (

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -48,6 +48,8 @@ export default function ForegroundLayerDemo({
     useState<keyof typeof shaderMap>('randomPaint')
   const [decay, setDecay] = useState(0.95)
   const [paintWhileStill, setPaintWhileStill] = useState(false)
+  const [noiseSpeed, setNoiseSpeed] = useState(1)
+  const [noiseSize, setNoiseSize] = useState(0.05)
 
   const content: ForegroundContent =
     sourceName === 'text'
@@ -77,6 +79,10 @@ export default function ForegroundLayerDemo({
         setSourceName={(n) => setSourceName(n as 'diamond' | 'text')}
         textValue={textValue}
         setTextValue={setTextValue}
+        noiseSpeed={noiseSpeed}
+        setNoiseSpeed={setNoiseSpeed}
+        noiseSize={noiseSize}
+        setNoiseSize={setNoiseSize}
       />
       <DraggableForeground
         content={content}
@@ -86,6 +92,8 @@ export default function ForegroundLayerDemo({
         preprocessShader={preprocessMap[preprocessName]}
         svgSize={svgSize}
         paintWhileStill={paintWhileStill}
+        noiseSpeed={noiseSpeed}
+        noiseSize={noiseSize}
       />
     </>
   )

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -10,7 +10,6 @@ const vertexShader = `
   }
 `
 
-
 import type { MutableRefObject } from 'react'
 import type { DragSpringPose } from './useDragAndSpring'
 
@@ -22,7 +21,9 @@ export default function useFeedbackFBO(
   interpQueue?: MutableRefObject<DragSpringPose[]>,
   externalRef?: MutableRefObject<THREE.Group | null>,
   preprocessShader: string | null = null,
-  preprocessRadius = 1
+  preprocessRadius = 1,
+  noiseSpeed = 1,
+  noiseSize = 0.05
 ) {
   const { gl, size, camera } = useThree()
   const dpr = gl.getPixelRatio()
@@ -94,8 +95,10 @@ export default function useFeedbackFBO(
       uDecay: { value: decay },
       uSessionRandom: { value: sessionRandom.current.clone() },
       uTime: { value: 0 },
+      uNoiseSpeed: { value: noiseSpeed },
+      uNoiseSize: { value: noiseSize },
     }),
-    [decay]
+    [decay, noiseSpeed, noiseSize]
   )
 
   const quadScene = useMemo(() => {

--- a/src/shaders/rippleFade.frag
+++ b/src/shaders/rippleFade.frag
@@ -5,25 +5,125 @@ uniform sampler2D uPrevFrame;
 uniform sampler2D uSnapshot;
 uniform float uDecay;
 uniform float uTime;
+uniform float uNoiseSpeed;
+uniform float uNoiseSize;
+uniform vec3 uSessionRandom;
 
-float random(vec2 st){
-  return fract(sin(dot(st, vec2(12.9898,78.233))) * 43758.5453123);
+vec3 mod289(vec3 x) {
+  return x - floor(x * (1.0 / 289.0)) * 289.0;
 }
 
-float noise(vec2 st){
-  vec2 i = floor(st);
-  vec2 f = fract(st);
-  vec2 u = f * f * (3.0 - 2.0 * f);
-  return mix(mix(random(i), random(i + vec2(1.0, 0.0)), u.x),
-             mix(random(i + vec2(0.0, 1.0)), random(i + vec2(1.0, 1.0)), u.x),
-             u.y);
+vec4 mod289(vec4 x) {
+  return x - floor(x * (1.0 / 289.0)) * 289.0;
 }
 
-void main(){
-    vec2 uv=vUv;
-    float n=noise(uv*4.0+uTime*0.5);
-    uv+= (n-0.5)*0.05;
-    vec4 history=texture2D(uPrevFrame,uv)*uDecay;
-    vec4 snap=texture2D(uSnapshot,vUv);
-    gl_FragColor=history+snap;
+vec4 permute(vec4 x) {
+  return mod289(((x * 34.0) + 1.0) * x);
+}
+
+vec4 taylorInvSqrt(vec4 r) {
+  return 1.79284291400159 - 0.85373472095314 * r;
+}
+
+vec3 fade(vec3 t) {
+  return t * t * t * (t * (t * 6.0 - 15.0) + 10.0);
+}
+
+float cnoise(vec3 P) {
+  vec3 Pi0 = floor(P);
+  vec3 Pi1 = Pi0 + vec3(1.0);
+  Pi0 = mod289(Pi0);
+  Pi1 = mod289(Pi1);
+  vec3 Pf0 = fract(P);
+  vec3 Pf1 = Pf0 - vec3(1.0);
+  vec4 ix = vec4(Pi0.x, Pi1.x, Pi0.x, Pi1.x);
+  vec4 iy = vec4(Pi0.yy, Pi1.yy);
+  vec4 iz0 = Pi0.zzzz;
+  vec4 iz1 = Pi1.zzzz;
+
+  vec4 ixy = permute(permute(ix) + iy);
+  vec4 ixy0 = permute(ixy + iz0);
+  vec4 ixy1 = permute(ixy + iz1);
+
+  vec4 gx0 = ixy0 * (1.0 / 7.0);
+  vec4 gy0 = fract(floor(gx0) * (1.0 / 7.0)) - 0.5;
+  gx0 = fract(gx0);
+  vec4 gz0 = vec4(0.5) - abs(gx0) - abs(gy0);
+  vec4 sz0 = step(gz0, vec4(0.0));
+  gx0 -= sz0 * (step(0.0, gx0) - 0.5);
+  gy0 -= sz0 * (step(0.0, gy0) - 0.5);
+
+  vec4 gx1 = ixy1 * (1.0 / 7.0);
+  vec4 gy1 = fract(floor(gx1) * (1.0 / 7.0)) - 0.5;
+  gx1 = fract(gx1);
+  vec4 gz1 = vec4(0.5) - abs(gx1) - abs(gy1);
+  vec4 sz1 = step(gz1, vec4(0.0));
+  gx1 -= sz1 * (step(0.0, gx1) - 0.5);
+  gy1 -= sz1 * (step(0.0, gy1) - 0.5);
+
+  vec3 g000 = vec3(gx0.x, gy0.x, gz0.x);
+  vec3 g100 = vec3(gx0.y, gy0.y, gz0.y);
+  vec3 g010 = vec3(gx0.z, gy0.z, gz0.z);
+  vec3 g110 = vec3(gx0.w, gy0.w, gz0.w);
+  vec3 g001 = vec3(gx1.x, gy1.x, gz1.x);
+  vec3 g101 = vec3(gx1.y, gy1.y, gz1.y);
+  vec3 g011 = vec3(gx1.z, gy1.z, gz1.z);
+  vec3 g111 = vec3(gx1.w, gy1.w, gz1.w);
+
+  vec4 norm0 = taylorInvSqrt(
+    vec4(dot(g000, g000), dot(g010, g010), dot(g100, g100), dot(g110, g110))
+  );
+  g000 *= norm0.x;
+  g010 *= norm0.y;
+  g100 *= norm0.z;
+  g110 *= norm0.w;
+  vec4 norm1 = taylorInvSqrt(
+    vec4(dot(g001, g001), dot(g011, g011), dot(g101, g101), dot(g111, g111))
+  );
+  g001 *= norm1.x;
+  g011 *= norm1.y;
+  g101 *= norm1.z;
+  g111 *= norm1.w;
+
+  float n000 = dot(g000, Pf0);
+  float n100 = dot(g100, vec3(Pf1.x, Pf0.yz));
+  float n010 = dot(g010, vec3(Pf0.x, Pf1.y, Pf0.z));
+  float n110 = dot(g110, vec3(Pf1.xy, Pf0.z));
+  float n001 = dot(g001, vec3(Pf0.xy, Pf1.z));
+  float n101 = dot(g101, vec3(Pf1.x, Pf0.y, Pf1.z));
+  float n011 = dot(g011, vec3(Pf0.x, Pf1.yz));
+  float n111 = dot(g111, Pf1);
+
+  vec3 fade_xyz = fade(Pf0);
+  vec4 n_z = mix(
+    vec4(n000, n100, n010, n110),
+    vec4(n001, n101, n011, n111),
+    fade_xyz.z
+  );
+  vec2 n_yz = mix(n_z.xy, n_z.zw, fade_xyz.y);
+  float n_xyz = mix(n_yz.x, n_yz.y, fade_xyz.x);
+  return 2.2 * n_xyz;
+}
+
+void main() {
+  vec2 lookup = vUv * 4.0;
+  float t = uTime * uNoiseSpeed;
+  vec2 offset;
+  offset.x = cnoise(vec3(lookup, t));
+  offset.y = cnoise(vec3(lookup, t + 1000.0));
+  vec2 uv = vUv + offset * uNoiseSize;
+
+  vec4 history = texture2D(uPrevFrame, uv);
+  float oldAlpha = history.a * uDecay;
+  vec3 oldColor = history.rgb;
+
+  float newAlpha = texture2D(uSnapshot, vUv).a;
+  vec3 newColor = uSessionRandom;
+
+  float outAlpha = newAlpha + oldAlpha * (1.0 - newAlpha);
+  vec3 outColor =
+    (newColor * newAlpha + oldColor * oldAlpha * (1.0 - newAlpha)) /
+    max(outAlpha, 1e-5);
+
+  gl_FragColor = vec4(outColor, outAlpha);
 }


### PR DESCRIPTION
## Summary
- use Perlin noise lookup in `rippleFade.frag`
- expose noise speed and size uniforms via `useFeedbackFBO`
- add tweakpane sliders for noise controls in `DemoControls`
- thread new values through `DraggableForeground` and demo
- log progress in `AGENTS.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a0b6ef6d08332a94a36466eb82b70