### PR TITLE
Fix paint while still option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,8 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **50** – Fixed "paint while still" checkbox using `addBinding` so it renders correctly. Lint and build pass.
 - **51** – Added Perlin-noise offset to `rippleFade.frag` with tweakable speed and size; new sliders wired through `DemoControls` and `useFeedbackFBO`.
 
+- **52** – Fixed "paint while still" so snapshots render every frame when enabled. Updated `useFeedbackFBO` and its call site. Lint and build pass.
+
 ## Next Steps
 
 - Tune random paint and ripple fade blending for performance and visual quality.

--- a/src/components/DraggableForeground.tsx
+++ b/src/components/DraggableForeground.tsx
@@ -47,7 +47,8 @@ export default function DraggableForeground({
     preprocessShader,
     stepSize,
     noiseSpeed,
-    noiseSize
+    noiseSize,
+    paintWhileStill
   )
 
   return (

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -23,7 +23,8 @@ export default function useFeedbackFBO(
   preprocessShader: string | null = null,
   preprocessRadius = 1,
   noiseSpeed = 1,
-  noiseSize = 0.05
+  noiseSize = 0.05,
+  paintWhileStill = false
 ) {
   const { gl, size, camera } = useThree()
   const dpr = gl.getPixelRatio()
@@ -174,6 +175,7 @@ export default function useFeedbackFBO(
       gl.autoClear = false
       for (const p of poses) {
         if (
+          paintWhileStill ||
           p.x !== lastSnapshotPos.current.x ||
           p.y !== lastSnapshotPos.current.y
         ) {


### PR DESCRIPTION
## Summary
- ensure the snapshot group renders every frame when `paint while still` is enabled
- propagate the option through `DraggableForeground`
- document fix in AGENTS log

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686aad9890bc833294850586d2f6dd90