### PR TITLE
Add intro overlay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 
 - **52** – Fixed "paint while still" so snapshots render every frame when enabled. Updated `useFeedbackFBO` and its call site. Lint and build pass.
 - **53** – Added IntroOverlay with project description that fades out on drag start.
+- **54** – Fixed overlay rendering by wrapping it in Drei's Html so it doesn't break the R3F canvas. Lint and build pass.
 
 ## Next Steps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **52** – Fixed "paint while still" so snapshots render every frame when enabled. Updated `useFeedbackFBO` and its call site. Lint and build pass.
 - **53** – Added IntroOverlay with project description that fades out on drag start.
 - **54** – Fixed overlay rendering by wrapping it in Drei's Html so it doesn't break the R3F canvas. Lint and build pass.
+- **55** – Moved IntroOverlay outside Canvas; now rendered in App with absolute positioning and responsive width. State lifted to hide on drag. Lint and build pass.
 
 ## Next Steps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **51** – Added Perlin-noise offset to `rippleFade.frag` with tweakable speed and size; new sliders wired through `DemoControls` and `useFeedbackFBO`.
 
 - **52** – Fixed "paint while still" so snapshots render every frame when enabled. Updated `useFeedbackFBO` and its call site. Lint and build pass.
+- **53** – Added IntroOverlay with project description that fades out on drag start.
 
 ## Next Steps
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import CanvasStage from './components/CanvasStage'
+import IntroOverlay from './components/IntroOverlay'
 import './App.css'
 import wildflowersUrl from './assets/wildflowers.png'
 import { useState } from 'react'
@@ -10,16 +11,22 @@ function useInitialBgName(): 'wildflowers' | 'white' {
 
 export default function App() {
   const [bgName, setBgName] = useState<'wildflowers' | 'white'>(useInitialBgName)
+  const [showIntro, setShowIntro] = useState(true)
   const style =
     bgName === 'wildflowers'
       ? { backgroundImage: `url(${wildflowersUrl})` }
       : { backgroundColor: '#ffffff' }
   return (
     <div
-      className="w-screen h-screen overflow-hidden bg-cover bg-center"
+      className="relative w-screen h-screen overflow-hidden bg-cover bg-center"
       style={style}
     >
-      <CanvasStage backgroundName={bgName} setBackgroundName={setBgName} />
+      <IntroOverlay visible={showIntro} />
+      <CanvasStage
+        backgroundName={bgName}
+        setBackgroundName={setBgName}
+        onInteract={() => setShowIntro(false)}
+      />
     </div>
   )
 }

--- a/src/components/CanvasStage.tsx
+++ b/src/components/CanvasStage.tsx
@@ -5,11 +5,13 @@ import ForegroundLayerDemo from './ForegroundLayerDemo'
 export type CanvasStageProps = {
   backgroundName: 'wildflowers' | 'white'
   setBackgroundName: (name: 'wildflowers' | 'white') => void
+  onInteract: () => void
 }
 
 export default function CanvasStage({
   backgroundName,
   setBackgroundName,
+  onInteract,
 }: CanvasStageProps) {
   return (
     <Canvas className="w-full h-full">
@@ -17,6 +19,7 @@ export default function CanvasStage({
         <ForegroundLayerDemo
           backgroundName={backgroundName}
           setBackgroundName={setBackgroundName}
+          onInteract={onInteract}
         />
       </Suspense>
     </Canvas>

--- a/src/components/DraggableForeground.tsx
+++ b/src/components/DraggableForeground.tsx
@@ -1,5 +1,5 @@
 import { a } from '@react-spring/three'
-import { useRef } from 'react'
+import { useRef, useEffect } from 'react'
 import * as THREE from 'three'
 import useDragAndSpring from '../hooks/useDragAndSpring'
 import useFrameInterpolator from '../hooks/useFrameInterpolator'
@@ -20,6 +20,7 @@ export type DraggableForegroundProps = {
   paintWhileStill: boolean
   noiseSpeed: number
   noiseSize: number
+  onInteract?: () => void
 }
 
 export default function DraggableForeground({
@@ -32,6 +33,7 @@ export default function DraggableForeground({
   paintWhileStill,
   noiseSpeed,
   noiseSize,
+  onInteract,
 }: DraggableForegroundProps) {
   const dragRef = useRef<THREE.Group | null>(null)
   const { bind, pose, active, interactionSession, isDragging } =
@@ -50,6 +52,10 @@ export default function DraggableForeground({
     noiseSize,
     paintWhileStill
   )
+
+  useEffect(() => {
+    if (interactionSession > 0) onInteract?.()
+  }, [interactionSession, onInteract])
 
   return (
     <>

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -9,6 +9,7 @@ import type { ForegroundContent } from '../types/foreground'
 import type { SvgSize } from '../types/svg'
 import DemoControls from './DemoControls'
 import DraggableForeground from './DraggableForeground'
+import IntroOverlay from './IntroOverlay'
 
 function useSvgUrl(): string {
   const params = new URLSearchParams(window.location.search)
@@ -50,6 +51,9 @@ export default function ForegroundLayerDemo({
   const [paintWhileStill, setPaintWhileStill] = useState(false)
   const [noiseSpeed, setNoiseSpeed] = useState(1)
   const [noiseSize, setNoiseSize] = useState(0.05)
+  const [showIntro, setShowIntro] = useState(true)
+
+  const handleInteract = () => setShowIntro(false)
 
   const content: ForegroundContent =
     sourceName === 'text'
@@ -58,6 +62,7 @@ export default function ForegroundLayerDemo({
 
   return (
     <>
+      <IntroOverlay visible={showIntro} />
       <DemoControls
         backgroundName={backgroundName}
         setBackgroundName={setBackgroundName}
@@ -94,6 +99,7 @@ export default function ForegroundLayerDemo({
         paintWhileStill={paintWhileStill}
         noiseSpeed={noiseSpeed}
         noiseSize={noiseSize}
+        onInteract={handleInteract}
       />
     </>
   )

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -9,7 +9,6 @@ import type { ForegroundContent } from '../types/foreground'
 import type { SvgSize } from '../types/svg'
 import DemoControls from './DemoControls'
 import DraggableForeground from './DraggableForeground'
-import IntroOverlay from './IntroOverlay'
 
 function useSvgUrl(): string {
   const params = new URLSearchParams(window.location.search)
@@ -19,11 +18,13 @@ function useSvgUrl(): string {
 export type ForegroundLayerDemoProps = {
   backgroundName: 'wildflowers' | 'white'
   setBackgroundName: (name: 'wildflowers' | 'white') => void
+  onInteract: () => void
 }
 
 export default function ForegroundLayerDemo({
   backgroundName,
   setBackgroundName,
+  onInteract,
 }: ForegroundLayerDemoProps) {
   const svgUrl = useSvgUrl()
   const [stepSize, setStepSize] = useState(2)
@@ -51,9 +52,6 @@ export default function ForegroundLayerDemo({
   const [paintWhileStill, setPaintWhileStill] = useState(false)
   const [noiseSpeed, setNoiseSpeed] = useState(1)
   const [noiseSize, setNoiseSize] = useState(0.05)
-  const [showIntro, setShowIntro] = useState(true)
-
-  const handleInteract = () => setShowIntro(false)
 
   const content: ForegroundContent =
     sourceName === 'text'
@@ -62,7 +60,6 @@ export default function ForegroundLayerDemo({
 
   return (
     <>
-      <IntroOverlay visible={showIntro} />
       <DemoControls
         backgroundName={backgroundName}
         setBackgroundName={setBackgroundName}
@@ -99,7 +96,7 @@ export default function ForegroundLayerDemo({
         paintWhileStill={paintWhileStill}
         noiseSpeed={noiseSpeed}
         noiseSize={noiseSize}
-        onInteract={handleInteract}
+        onInteract={onInteract}
       />
     </>
   )

--- a/src/components/IntroOverlay.tsx
+++ b/src/components/IntroOverlay.tsx
@@ -2,18 +2,22 @@ export type IntroOverlayProps = {
   visible: boolean
 }
 
+import { Html } from '@react-three/drei'
+
 export default function IntroOverlay({ visible }: IntroOverlayProps) {
   return (
-    <div
-      className={`absolute top-0 left-0 z-10 p-4 transition-opacity duration-500 pointer-events-none w-full sm:w-auto sm:max-w-md ${
-        visible ? 'opacity-100' : 'opacity-0'
-      }`}
-    >
-      <h1 className="text-2xl font-bold mb-2">Feedbackground</h1>
-      <p className="leading-snug">
-        Feedback in the background. Grab the foreground layer below and move it
-        around to see the effect. Adjust the params to your heart\'s content.
-      </p>
-    </div>
+    <Html prepend>
+      <div
+        className={`absolute top-0 left-0 z-10 p-4 transition-opacity duration-500 pointer-events-none w-full sm:w-auto sm:max-w-md ${
+          visible ? 'opacity-100' : 'opacity-0'
+        }`}
+      >
+        <h1 className="text-2xl font-bold mb-2">Feedbackground</h1>
+        <p className="leading-snug">
+          Feedback in the background. Grab the foreground layer below and move it
+          around to see the effect. Adjust the params to your heart&apos;s content.
+        </p>
+      </div>
+    </Html>
   )
 }

--- a/src/components/IntroOverlay.tsx
+++ b/src/components/IntroOverlay.tsx
@@ -2,22 +2,18 @@ export type IntroOverlayProps = {
   visible: boolean
 }
 
-import { Html } from '@react-three/drei'
-
 export default function IntroOverlay({ visible }: IntroOverlayProps) {
   return (
-    <Html prepend>
-      <div
-        className={`absolute top-0 left-0 z-10 p-4 transition-opacity duration-500 pointer-events-none w-full sm:w-auto sm:max-w-md ${
-          visible ? 'opacity-100' : 'opacity-0'
-        }`}
-      >
-        <h1 className="text-2xl font-bold mb-2">Feedbackground</h1>
-        <p className="leading-snug">
-          Feedback in the background. Grab the foreground layer below and move it
-          around to see the effect. Adjust the params to your heart&apos;s content.
-        </p>
-      </div>
-    </Html>
+    <div
+      className={`absolute top-0 left-0 z-10 p-4 transition-opacity duration-500 pointer-events-none bg-white/90 w-full sm:w-[300px] ${
+        visible ? 'opacity-100' : 'opacity-0'
+      }`}
+    >
+      <h1 className="text-2xl font-bold mb-2">Feedbackground</h1>
+      <p className="leading-snug">
+        Feedback in the background. Grab the foreground layer below and move it
+        around to see the effect. Adjust the params to your heart&apos;s content.
+      </p>
+    </div>
   )
 }

--- a/src/components/IntroOverlay.tsx
+++ b/src/components/IntroOverlay.tsx
@@ -1,0 +1,19 @@
+export type IntroOverlayProps = {
+  visible: boolean
+}
+
+export default function IntroOverlay({ visible }: IntroOverlayProps) {
+  return (
+    <div
+      className={`absolute top-0 left-0 z-10 p-4 transition-opacity duration-500 pointer-events-none w-full sm:w-auto sm:max-w-md ${
+        visible ? 'opacity-100' : 'opacity-0'
+      }`}
+    >
+      <h1 className="text-2xl font-bold mb-2">Feedbackground</h1>
+      <p className="leading-snug">
+        Feedback in the background. Grab the foreground layer below and move it
+        around to see the effect. Adjust the params to your heart\'s content.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- display an IntroOverlay with project title and description
- hide the overlay after the first drag interaction

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ab768f794833283941ed46eb5d8a0