### PR TITLE
Add detail parameter to ripple effect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **58** – Added "center zoom" toggle to switch ripple zoom between canvas center and foreground. Lint and build pass.
 - **59** – Faded out new Overview panel on first drag and hid Tweakpane on small screens. Lint and build pass.
 - **60** – Moved DemoControls outside the R3F Canvas by hoisting state to `App` and updating component props. Lint and build pass.
+- **61** – Added noise "detail" parameter to ripple fade effect with new Tweakpane slider and shader uniform. Lint and build pass.
 
 ## Next Steps
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,19 +17,23 @@ function useInitialText(): string {
 }
 
 export default function App() {
-  const [bgName, setBgName] = useState<'wildflowers' | 'white'>(useInitialBgName)
+  const [bgName, setBgName] = useState<'wildflowers' | 'white'>(
+    useInitialBgName
+  )
   const [overviewHidden, setOverviewHidden] = useState(false)
   const [stepSize, setStepSize] = useState(1)
   const [preprocessName, setPreprocessName] = useState<'none' | 'blur'>('blur')
   const [svgSize, setSvgSize] = useState<SvgSize>({ type: 'scaled', factor: 2 })
   const [sourceName, setSourceName] = useState<'diamond' | 'text'>('text')
   const [textValue, setTextValue] = useState(useInitialText())
-  const [shaderName, setShaderName] =
-    useState<'motionBlur' | 'randomPaint' | 'rippleFade'>('rippleFade')
+  const [shaderName, setShaderName] = useState<
+    'motionBlur' | 'randomPaint' | 'rippleFade'
+  >('rippleFade')
   const [decay, setDecay] = useState(0.975)
   const [paintWhileStill, setPaintWhileStill] = useState(false)
   const [speed, setSpeed] = useState(0.05)
   const [displacement, setDisplacement] = useState(0.0015)
+  const [detail, setDetail] = useState(1)
   const [zoom, setZoom] = useState(0)
   const [centerZoom, setCenterZoom] = useState(false)
   const style =
@@ -62,6 +66,8 @@ export default function App() {
         setSpeed={setSpeed}
         displacement={displacement}
         setDisplacement={setDisplacement}
+        detail={detail}
+        setDetail={setDetail}
         zoom={zoom}
         setZoom={setZoom}
         centerZoom={centerZoom}
@@ -82,6 +88,7 @@ export default function App() {
           textValue={textValue}
           speed={speed}
           displacement={displacement}
+          detail={detail}
           zoom={zoom}
           centerZoom={centerZoom}
           onInteract={() => setOverviewHidden(true)}

--- a/src/components/CanvasStage.tsx
+++ b/src/components/CanvasStage.tsx
@@ -14,6 +14,7 @@ export type CanvasStageProps = {
   textValue: string
   speed: number
   displacement: number
+  detail: number
   zoom: number
   centerZoom: boolean
   onInteract: () => void
@@ -30,6 +31,7 @@ export default function CanvasStage({
   textValue,
   speed,
   displacement,
+  detail,
   zoom,
   centerZoom,
   onInteract,
@@ -48,6 +50,7 @@ export default function CanvasStage({
           textValue={textValue}
           speed={speed}
           displacement={displacement}
+          detail={detail}
           zoom={zoom}
           centerZoom={centerZoom}
           onInteract={onInteract}

--- a/src/components/DemoControls.tsx
+++ b/src/components/DemoControls.tsx
@@ -15,6 +15,8 @@ export type DemoControlsProps = {
   setSpeed: (val: number) => void
   displacement: number
   setDisplacement: (val: number) => void
+  detail: number
+  setDetail: (val: number) => void
   zoom: number
   setZoom: (val: number) => void
   centerZoom: boolean
@@ -44,6 +46,8 @@ export default function DemoControls({
   setSpeed,
   displacement,
   setDisplacement,
+  detail,
+  setDetail,
   zoom,
   setZoom,
   centerZoom,
@@ -111,6 +115,18 @@ export default function DemoControls({
         })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         sizeInputNoise.on('change', (ev: any) => setDisplacement(ev.value))
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const detailInput = (effectParamsFolder as any).addBlade({
+          view: 'slider',
+          label: 'detail',
+          min: 0.1,
+          max: 5,
+          value: detail,
+          step: 0.01,
+        })
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        detailInput.on('change', (ev: any) => setDetail(ev.value))
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const zoomInput = (effectParamsFolder as any).addBlade({

--- a/src/components/DraggableForeground.tsx
+++ b/src/components/DraggableForeground.tsx
@@ -20,6 +20,7 @@ export type DraggableForegroundProps = {
   paintWhileStill: boolean
   speed: number
   displacement: number
+  detail: number
   zoom: number
   centerZoom: boolean
   onGrab?: () => void
@@ -35,6 +36,7 @@ export default function DraggableForeground({
   paintWhileStill,
   speed,
   displacement,
+  detail,
   zoom,
   centerZoom,
   onGrab,
@@ -59,6 +61,7 @@ export default function DraggableForeground({
     stepSize,
     speed,
     displacement,
+    detail,
     zoom,
     centerZoom,
     paintWhileStill

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -12,7 +12,6 @@ function useSvgUrl(): string {
   return params.get('svg') || defaultSvgUrl
 }
 
-
 export type ForegroundLayerDemoProps = {
   shaderName: 'motionBlur' | 'randomPaint' | 'rippleFade'
   decay: number
@@ -24,6 +23,7 @@ export type ForegroundLayerDemoProps = {
   textValue: string
   speed: number
   displacement: number
+  detail: number
   zoom: number
   centerZoom: boolean
   onInteract: () => void
@@ -40,6 +40,7 @@ export default function ForegroundLayerDemo({
   textValue,
   speed,
   displacement,
+  detail,
   zoom,
   centerZoom,
   onInteract,
@@ -72,6 +73,7 @@ export default function ForegroundLayerDemo({
         paintWhileStill={paintWhileStill}
         speed={speed}
         displacement={displacement}
+        detail={detail}
         zoom={zoom}
         centerZoom={centerZoom}
         onGrab={onInteract}

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -24,6 +24,7 @@ export default function useFeedbackFBO(
   preprocessRadius = 1,
   speed = 0.05,
   displacement = 0.0015,
+  detail = 1,
   zoom = 0,
   centerZoom = false,
   paintWhileStill = false
@@ -100,10 +101,11 @@ export default function useFeedbackFBO(
       uTime: { value: 0 },
       uSpeed: { value: speed },
       uDisplacement: { value: displacement },
+      uDetail: { value: detail },
       uZoom: { value: zoom },
       uCenter: { value: new THREE.Vector2(0.5, 0.5) },
     }),
-    [decay, speed, displacement, zoom]
+    [decay, speed, displacement, detail, zoom]
   )
 
   const quadScene = useMemo(() => {

--- a/src/shaders/rippleFade.frag
+++ b/src/shaders/rippleFade.frag
@@ -7,6 +7,7 @@ uniform float uDecay;
 uniform float uTime;
 uniform float uSpeed;
 uniform float uDisplacement;
+uniform float uDetail;
 uniform float uZoom;
 uniform vec2 uCenter;
 uniform vec3 uSessionRandom;
@@ -109,7 +110,7 @@ float cnoise(vec3 P) {
 
 void main() {
   vec2 zoomed = (vUv - uCenter) * (1.0 + uZoom) + uCenter;
-  vec2 lookup = zoomed * 4.0;
+  vec2 lookup = zoomed * 4.0 * uDetail;
   float t = uTime * uSpeed;
   vec2 offset;
   offset.x = cnoise(vec3(lookup, t));


### PR DESCRIPTION
## Summary
- add noise detail parameter to rippleFade shader and Tweakpane controls
- plumb `detail` uniform through component hierarchy and into `useFeedbackFBO`
- multiply noise input space by `uDetail` for customizable detail level

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686be1ae95cc8332bc770b4b3df0fa66