### PR TITLE
Add effect url parameter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import CanvasStage from './components/CanvasStage'
 import DemoControls from './components/DemoControls'
 import Overview from './components/Overview'
 import type { SvgSize } from './types/svg'
+import { effectIndex, type EffectName } from './effects'
 
 function useInitialBgName(): 'wildflowers' | 'white' {
   const params = new URLSearchParams(window.location.search)
@@ -14,6 +15,12 @@ function useInitialBgName(): 'wildflowers' | 'white' {
 function useInitialText(): string {
   const params = new URLSearchParams(window.location.search)
   return params.get('text') || 'Hello'
+}
+
+function useInitialEffect(): EffectName {
+  const params = new URLSearchParams(window.location.search)
+  const name = params.get('effect') as EffectName | null
+  return name && name in effectIndex ? name : 'rippleFade'
 }
 
 export default function App() {
@@ -26,9 +33,7 @@ export default function App() {
   const [svgSize, setSvgSize] = useState<SvgSize>({ type: 'scaled', factor: 2 })
   const [sourceName, setSourceName] = useState<'diamond' | 'text'>('text')
   const [textValue, setTextValue] = useState(useInitialText())
-  const [shaderName, setShaderName] = useState<
-    'motionBlur' | 'randomPaint' | 'rippleFade'
-  >('rippleFade')
+  const [shaderName, setShaderName] = useState<EffectName>(useInitialEffect())
   const [decay, setDecay] = useState(0.98)
   const [paintWhileStill, setPaintWhileStill] = useState(false)
   const [speed, setSpeed] = useState(0.05)
@@ -47,7 +52,7 @@ export default function App() {
         backgroundName={bgName}
         setBackgroundName={setBgName}
         shaderName={shaderName}
-        setShaderName={setShaderName as (name: string) => void}
+        setShaderName={setShaderName}
         decay={decay}
         setDecay={setDecay}
         stepSize={stepSize}

--- a/src/components/CanvasStage.tsx
+++ b/src/components/CanvasStage.tsx
@@ -2,9 +2,10 @@ import { Canvas } from '@react-three/fiber'
 import { Suspense } from 'react'
 import ForegroundLayerDemo from './ForegroundLayerDemo'
 import type { SvgSize } from '../types/svg'
+import type { EffectName } from '../effects'
 
 export type CanvasStageProps = {
-  shaderName: 'motionBlur' | 'randomPaint' | 'rippleFade'
+  shaderName: EffectName
   decay: number
   stepSize: number
   preprocessName: 'none' | 'blur'

--- a/src/components/DemoControls.tsx
+++ b/src/components/DemoControls.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef } from 'react'
 import { Pane } from 'tweakpane'
 import type { SvgSize } from '../types/svg'
+import { effectIndex, type EffectName } from '../effects'
 
 export type DemoControlsProps = {
   backgroundName: 'wildflowers' | 'white'
   setBackgroundName: (name: 'wildflowers' | 'white') => void
-  shaderName: string
-  setShaderName: (name: string) => void
+  shaderName: EffectName
+  setShaderName: (name: EffectName) => void
   decay: number
   setDecay: (val: number) => void
   stepSize: number
@@ -80,7 +81,7 @@ export default function DemoControls({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let effectParamsFolder: any
 
-    const createEffectParamsFolder = (shader: string) => {
+    const createEffectParamsFolder = (shader: EffectName) => {
       if (effectParamsFolder) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ;(pane as any).remove(effectParamsFolder)
@@ -266,22 +267,23 @@ export default function DemoControls({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     preprocessInput.on('change', (ev: any) => setPreprocessName(ev.value))
 
+    const shaderOptions = Object.entries(effectIndex).map(([key, val]) => ({
+      text: val.label,
+      value: key,
+    }))
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const shaderInput = (effectFolder as any).addBlade({
       view: 'list',
       label: 'shader',
-      options: [
-        { text: 'Motion Blur', value: 'motionBlur' },
-        { text: 'Random Paint', value: 'randomPaint' },
-        { text: 'Ripple Fade', value: 'rippleFade' },
-      ],
+      options: shaderOptions,
       value: shaderName,
       index: 3,
     })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     shaderInput.on('change', (ev: any) => {
-      setShaderName(ev.value)
-      createEffectParamsFolder(ev.value)
+      const val = ev.value as EffectName
+      setShaderName(val)
+      createEffectParamsFolder(val)
     })
 
     createEffectParamsFolder(shaderName)

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -1,8 +1,6 @@
 import defaultSvgUrl from '../assets/diamond.svg?url'
 import gaussianBlurFrag from '../shaders/gaussianBlur.frag'
-import motionBlurFrag from '../shaders/motionBlur.frag'
-import randomPaintFrag from '../shaders/randomPaint.frag'
-import rippleFadeFrag from '../shaders/rippleFade.frag'
+import { effectIndex, type EffectName } from '../effects'
 import type { ForegroundContent } from '../types/foreground'
 import type { SvgSize } from '../types/svg'
 import DraggableForeground from './DraggableForeground'
@@ -13,7 +11,7 @@ function useSvgUrl(): string {
 }
 
 export type ForegroundLayerDemoProps = {
-  shaderName: 'motionBlur' | 'randomPaint' | 'rippleFade'
+  shaderName: EffectName
   decay: number
   stepSize: number
   preprocessName: 'none' | 'blur'
@@ -50,11 +48,6 @@ export default function ForegroundLayerDemo({
     none: null,
     blur: gaussianBlurFrag,
   }
-  const shaderMap = {
-    motionBlur: motionBlurFrag,
-    randomPaint: randomPaintFrag,
-    rippleFade: rippleFadeFrag,
-  }
 
   const content: ForegroundContent =
     sourceName === 'text'
@@ -65,7 +58,7 @@ export default function ForegroundLayerDemo({
     <>
       <DraggableForeground
         content={content}
-        shader={shaderMap[shaderName]}
+        shader={effectIndex[shaderName].shader}
         decay={decay}
         stepSize={stepSize}
         preprocessShader={preprocessMap[preprocessName]}

--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -1,0 +1,11 @@
+import motionBlurFrag from '../shaders/motionBlur.frag'
+import randomPaintFrag from '../shaders/randomPaint.frag'
+import rippleFadeFrag from '../shaders/rippleFade.frag'
+
+export const effectIndex = {
+  motionBlur: { label: 'Motion Blur', shader: motionBlurFrag },
+  randomPaint: { label: 'Random Paint', shader: randomPaintFrag },
+  rippleFade: { label: 'Ripple Fade', shader: rippleFadeFrag },
+} as const
+
+export type EffectName = keyof typeof effectIndex


### PR DESCRIPTION
## Summary
- centralize shader details in a new `effectIndex`
- use `EffectName` everywhere instead of hard‑coded unions
- read a new `effect` query parameter in `App`
- populate the shader dropdown from `effectIndex`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68729473b46083329314d7412158c9a2