### PR TITLE
Refactor effect passes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **65** – Fixed pass buffer allocation so multi-pass effects don't crash and ripple fade parameters work again. Lint and build pass.
 - **66** – Corrected uniform names for pass parameters and ensured render targets resize when switching effects. Lint warns on hooks; build succeeds.
 - **67** – Removed pass descriptor names, refactored parameter plumbing, added blur radius control, and fixed interp step to constant. Lint warns; build succeeds.
+- **68** – Synced ripple effect parameters across effect switches using refs so tweakpane values persist. Lint warns; build succeeds.
 
 ## Next Steps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,11 +87,11 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **64** – Removed unused `uPreviousFrameLastPass` uniform and blur special casing. Blur now runs as a normal pass with radius from interpolation step. Updated shaders, hook, and docs. Lint and build pass.
 - **65** – Fixed pass buffer allocation so multi-pass effects don't crash and ripple fade parameters work again. Lint and build pass.
 - **66** – Corrected uniform names for pass parameters and ensured render targets resize when switching effects. Lint warns on hooks; build succeeds.
+- **67** – Removed pass descriptor names, refactored parameter plumbing, added blur radius control, and fixed interp step to constant. Lint warns; build succeeds.
 
 ## Next Steps
 
 - Implement more multi-pass effects using the new pipeline.
-- Hook up gaussian blur pass and other effect-specific parameters.
 - Tune random paint and ripple fade blending for performance and visual quality.
 - Profile high-DPR rendering performance and optimize FBO sizing.
 - Expose additional shader uniforms via Tweakpane for experimentation.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ App
 Each effect in `src/effects` declares an ordered list of passes following an
 implicit snapshot. Every frame starts by rendering the current foreground pose
 into a snapshot buffer; the resulting texture becomes the input for the first
-pass. A pass is `{ type: 'shader', fragment, name? }`.
+pass. A pass is `{ type: 'shader', fragment }`.
 `useFeedbackFBO` steps through the passes sequentially, piping textures from one
 to the next. Each shader receives uniforms:
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ export default function App() {
     useInitialBgName
   )
   const [overviewHidden, setOverviewHidden] = useState(false)
-  const [stepSize, setStepSize] = useState(1)
+  const [blurRadius, setBlurRadius] = useState(1)
   const [svgSize, setSvgSize] = useState<SvgSize>({ type: 'scaled', factor: 2 })
   const [sourceName, setSourceName] = useState<'diamond' | 'text'>('text')
   const [textValue, setTextValue] = useState(useInitialText())
@@ -54,8 +54,8 @@ export default function App() {
         setShaderName={setShaderName}
         decay={decay}
         setDecay={setDecay}
-        stepSize={stepSize}
-        setStepSize={setStepSize}
+        blurRadius={blurRadius}
+        setBlurRadius={setBlurRadius}
         svgSize={svgSize}
         setSvgSize={setSvgSize}
         paintWhileStill={paintWhileStill}
@@ -82,7 +82,7 @@ export default function App() {
         <CanvasStage
           shaderName={shaderName}
           decay={decay}
-          stepSize={stepSize}
+          blurRadius={blurRadius}
           svgSize={svgSize}
           paintWhileStill={paintWhileStill}
           sourceName={sourceName}

--- a/src/components/CanvasStage.tsx
+++ b/src/components/CanvasStage.tsx
@@ -7,7 +7,7 @@ import type { EffectName } from '../effects'
 export type CanvasStageProps = {
   shaderName: EffectName
   decay: number
-  stepSize: number
+  blurRadius: number
   svgSize: SvgSize
   paintWhileStill: boolean
   sourceName: 'diamond' | 'text'
@@ -23,7 +23,7 @@ export type CanvasStageProps = {
 export default function CanvasStage({
   shaderName,
   decay,
-  stepSize,
+  blurRadius,
   svgSize,
   paintWhileStill,
   sourceName,
@@ -41,7 +41,7 @@ export default function CanvasStage({
         <ForegroundLayerDemo
           shaderName={shaderName}
           decay={decay}
-          stepSize={stepSize}
+          blurRadius={blurRadius}
           svgSize={svgSize}
           paintWhileStill={paintWhileStill}
           sourceName={sourceName}

--- a/src/components/DemoControls.tsx
+++ b/src/components/DemoControls.tsx
@@ -61,10 +61,34 @@ export default function DemoControls({
   setTextValue,
 }: DemoControlsProps) {
   const sizeRef = useRef(svgSize)
+  const speedRef = useRef(speed)
+  const displacementRef = useRef(displacement)
+  const detailRef = useRef(detail)
+  const zoomRef = useRef(zoom)
+  const centerZoomRef = useRef(centerZoom)
+  const blurRadiusRef = useRef(blurRadius)
   const containerRef = useRef<HTMLDivElement | null>(null)
   useEffect(() => {
     sizeRef.current = svgSize
   }, [svgSize])
+  useEffect(() => {
+    speedRef.current = speed
+  }, [speed])
+  useEffect(() => {
+    displacementRef.current = displacement
+  }, [displacement])
+  useEffect(() => {
+    detailRef.current = detail
+  }, [detail])
+  useEffect(() => {
+    zoomRef.current = zoom
+  }, [zoom])
+  useEffect(() => {
+    centerZoomRef.current = centerZoom
+  }, [centerZoom])
+  useEffect(() => {
+    blurRadiusRef.current = blurRadius
+  }, [blurRadius])
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     const pane = new Pane({ container: containerRef.current ?? undefined })
@@ -95,7 +119,7 @@ export default function DemoControls({
           label: 'speed',
           min: 0,
           max: 0.3,
-          value: speed,
+          value: speedRef.current,
           step: 0.001,
         })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -107,7 +131,7 @@ export default function DemoControls({
           label: 'displacement',
           min: 0,
           max: 0.003,
-          value: displacement,
+          value: displacementRef.current,
           step: 0.0001,
         })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -119,7 +143,7 @@ export default function DemoControls({
           label: 'detail',
           min: 0.1,
           max: 5,
-          value: detail,
+          value: detailRef.current,
           step: 0.01,
         })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -131,13 +155,13 @@ export default function DemoControls({
           label: 'zoom',
           min: -0.02,
           max: 0.02,
-          value: zoom,
+          value: zoomRef.current,
           step: 0.0001,
         })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         zoomInput.on('change', (ev: any) => setZoom(ev.value))
 
-        const centerParams = { center: centerZoom }
+        const centerParams = { center: centerZoomRef.current }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const centerInput = (effectParamsFolder as any).addBinding(
           centerParams,
@@ -156,7 +180,7 @@ export default function DemoControls({
             label: 'blur radius',
             min: 0,
             max: 10,
-            value: blurRadius,
+            value: blurRadiusRef.current,
             step: 1,
           })
           // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/DemoControls.tsx
+++ b/src/components/DemoControls.tsx
@@ -10,8 +10,8 @@ export type DemoControlsProps = {
   setShaderName: (name: EffectName) => void
   decay: number
   setDecay: (val: number) => void
-  stepSize: number
-  setStepSize: (val: number) => void
+  blurRadius: number
+  setBlurRadius: (val: number) => void
   speed: number
   setSpeed: (val: number) => void
   displacement: number
@@ -39,8 +39,8 @@ export default function DemoControls({
   setShaderName,
   decay,
   setDecay,
-  stepSize,
-  setStepSize,
+  blurRadius,
+  setBlurRadius,
   speed,
   setSpeed,
   displacement,
@@ -83,7 +83,7 @@ export default function DemoControls({
         ;(pane as any).remove(effectParamsFolder)
         effectParamsFolder = null
       }
-      if (shader === 'rippleFade') {
+      if (shader === 'rippleFade' || shader === 'blurredRipple') {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         effectParamsFolder = (pane as any).addFolder({
           title: 'Effect Params',
@@ -149,6 +149,19 @@ export default function DemoControls({
           centerParams.center = ev.value
           setCenterZoom(ev.value)
         })
+        if (shader === 'blurredRipple') {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const blurInput = (effectParamsFolder as any).addBlade({
+            view: 'slider',
+            label: 'blur radius',
+            min: 0,
+            max: 10,
+            value: blurRadius,
+            step: 1,
+          })
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          blurInput.on('change', (ev: any) => setBlurRadius(ev.value))
+        }
       }
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -236,18 +249,6 @@ export default function DemoControls({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     decayInput.on('change', (ev: any) => setDecay(ev.value))
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const interpInput = (effectFolder as any).addBlade({
-      view: 'slider',
-      label: 'interp (px)',
-      min: 1,
-      max: 10,
-      value: stepSize,
-      step: 1,
-      index: 1,
-    })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    interpInput.on('change', (ev: any) => setStepSize(ev.value))
 
     const shaderOptions = Object.entries(effectIndex).map(([key, val]) => ({
       text: val.label,
@@ -259,7 +260,7 @@ export default function DemoControls({
       label: 'shader',
       options: shaderOptions,
       value: shaderName,
-      index: 2,
+      index: 1,
     })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     shaderInput.on('change', (ev: any) => {

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -12,7 +12,7 @@ function useSvgUrl(): string {
 export type ForegroundLayerDemoProps = {
   shaderName: EffectName
   decay: number
-  stepSize: number
+  blurRadius: number
   svgSize: SvgSize
   paintWhileStill: boolean
   sourceName: 'diamond' | 'text'
@@ -28,7 +28,7 @@ export type ForegroundLayerDemoProps = {
 export default function ForegroundLayerDemo({
   shaderName,
   decay,
-  stepSize,
+  blurRadius,
   svgSize,
   paintWhileStill,
   sourceName,
@@ -53,7 +53,7 @@ export default function ForegroundLayerDemo({
         content={content}
         passes={effectIndex[shaderName].passes}
         decay={decay}
-        stepSize={stepSize}
+        blurRadius={blurRadius}
         svgSize={svgSize}
         paintWhileStill={paintWhileStill}
         speed={speed}

--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -6,27 +6,26 @@ import gaussianBlurFrag from '../shaders/gaussianBlur.frag'
 export type PassDescriptor = {
   type: 'shader'
   fragment: string
-  name?: string
 }
 
 export const effectIndex = {
   motionBlur: {
     label: 'Motion Blur',
-    passes: [{ type: 'shader', fragment: motionBlurFrag, name: 'motionBlur' }],
+    passes: [{ type: 'shader', fragment: motionBlurFrag }],
   },
   randomPaint: {
     label: 'Random Paint',
-    passes: [{ type: 'shader', fragment: randomPaintFrag, name: 'randomPaint' }],
+    passes: [{ type: 'shader', fragment: randomPaintFrag }],
   },
   rippleFade: {
     label: 'Ripple Fade',
-    passes: [{ type: 'shader', fragment: rippleFadeFrag, name: 'rippleFade' }],
+    passes: [{ type: 'shader', fragment: rippleFadeFrag }],
   },
   blurredRipple: {
     label: 'Blurred Ripple',
     passes: [
-      { type: 'shader', fragment: gaussianBlurFrag, name: 'blur' },
-      { type: 'shader', fragment: rippleFadeFrag, name: 'rippleFade' },
+      { type: 'shader', fragment: gaussianBlurFrag },
+      { type: 'shader', fragment: rippleFadeFrag },
     ],
   },
 } as const

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -20,7 +20,8 @@ export default function useFeedbackFBO(
   sessionId = 0,
   interpQueue?: MutableRefObject<DragSpringPose[]>,
   externalRef?: MutableRefObject<THREE.Group | null>,
-  passParams: Record<string, Record<string, number | boolean>> = {},
+  passParams: Array<Record<string, number | boolean>> = [],
+  centerZoom = false,
   paintWhileStill = false
 ) {
   const { gl, size, camera, viewport } = useThree()
@@ -104,7 +105,7 @@ export default function useFeedbackFBO(
         },
         uPreviousPassThisFrame: { value: snapshotRT.current.texture },
       }
-      const extra = passParams[p.name ?? ''] ?? {}
+      const extra = passParams[idx] ?? {}
       for (const [k, v] of Object.entries(extra)) {
         if (uniforms[k]) uniforms[k].value = v
         else uniforms[k] = { value: v }
@@ -177,7 +178,6 @@ export default function useFeedbackFBO(
       if (p) p.uniforms.uTime.value = timeRef.current
     })
 
-    const centerZoom = Boolean(passParams.rippleFade?.centerZoom)
     if (centerZoom || !snapshotGroup.current) {
       passData.forEach((p) => {
         if (p && p.uniforms.uCenter)

--- a/src/hooks/useFrameInterpolator.ts
+++ b/src/hooks/useFrameInterpolator.ts
@@ -4,10 +4,12 @@ import { useRef, useEffect } from 'react'
 import type { MutableRefObject } from 'react'
 import type { DragSpringPose } from './useDragAndSpring'
 
+export const INTERP_STEP_PX = 1
+
 export default function useFrameInterpolator(
   pose: { x: SpringValue<number>; y: SpringValue<number> },
   isDragging: boolean,
-  stepPx = 20
+  stepPx = INTERP_STEP_PX
 ): MutableRefObject<DragSpringPose[]> {
   const { size, viewport, gl } = useThree()
   const lastPose = useRef<DragSpringPose>({


### PR DESCRIPTION
## Summary
- drop `name` from effect pass descriptors
- use array-based parameter lists in `useFeedbackFBO`
- fix interpolation step to a constant and add blur radius slider for blurred ripple
- remove `interp` slider
- thread new blur radius through components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872b84998388332a1c1576849bb3c39