### PR TITLE
Implement pass parameter registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **66** – Corrected uniform names for pass parameters and ensured render targets resize when switching effects. Lint warns on hooks; build succeeds.
 - **67** – Removed pass descriptor names, refactored parameter plumbing, added blur radius control, and fixed interp step to constant. Lint warns; build succeeds.
 - **68** – Synced ripple effect parameters across effect switches using refs so tweakpane values persist. Lint warns; build succeeds.
+- **69** – Refactored pass model to declare effect parameters per pass and auto-generate Tweakpane controls. Removed blur special-casing. Lint warns; build succeeds.
 
 ## Next Steps
 

--- a/src/components/DraggableForeground.tsx
+++ b/src/components/DraggableForeground.tsx
@@ -48,27 +48,24 @@ export default function DraggableForeground({
     onGrab?.()
   }
   const interpQueue = useFrameInterpolator(pose, isDragging, INTERP_STEP_PX)
-  const passParams: Record<string, number | boolean>[] =
-    passes.length > 1
-      ? [
-          { uRadius: blurRadius },
-          {
-            uSpeed: speed,
-            uDisplacement: displacement,
-            uDetail: detail,
-            uZoom: zoom,
-            centerZoom,
-          },
-        ]
-      : [
-          {
-            uSpeed: speed,
-            uDisplacement: displacement,
-            uDetail: detail,
-            uZoom: zoom,
-            centerZoom,
-          },
-        ]
+  const effectValues: Record<string, number | boolean> = {
+    blurRadius,
+    speed,
+    displacement,
+    detail,
+    zoom,
+    centerZoom,
+  }
+  const passParams = passes.map((p) => {
+    const obj: Record<string, number | boolean> = {}
+    p.params?.forEach((param) => {
+      const val = effectValues[param.id]
+      if (val !== undefined) {
+        obj[param.uniform ?? param.id] = val
+      }
+    })
+    return obj
+  })
   const { snapshotRef, texture } = useFeedbackFBO(
     passes,
     decay,

--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -3,9 +3,21 @@ import randomPaintFrag from '../shaders/randomPaint.frag'
 import rippleFadeFrag from '../shaders/rippleFade.frag'
 import gaussianBlurFrag from '../shaders/gaussianBlur.frag'
 
+export type PassParamDef = {
+  id: string
+  uniform?: string
+  type: 'number' | 'boolean'
+  label: string
+  default: number | boolean
+  min?: number
+  max?: number
+  step?: number
+}
+
 export type PassDescriptor = {
   type: 'shader'
   fragment: string
+  params?: readonly PassParamDef[]
 }
 
 export const effectIndex = {
@@ -19,16 +31,149 @@ export const effectIndex = {
   },
   rippleFade: {
     label: 'Ripple Fade',
-    passes: [{ type: 'shader', fragment: rippleFadeFrag }],
+    passes: [
+      {
+        type: 'shader',
+        fragment: rippleFadeFrag,
+        params: [
+          {
+            id: 'speed',
+            uniform: 'uSpeed',
+            type: 'number',
+            label: 'speed',
+            default: 0.05,
+            min: 0,
+            max: 0.3,
+            step: 0.001,
+          },
+          {
+            id: 'displacement',
+            uniform: 'uDisplacement',
+            type: 'number',
+            label: 'displacement',
+            default: 0.0015,
+            min: 0,
+            max: 0.003,
+            step: 0.0001,
+          },
+          {
+            id: 'detail',
+            uniform: 'uDetail',
+            type: 'number',
+            label: 'detail',
+            default: 2,
+            min: 0.1,
+            max: 5,
+            step: 0.01,
+          },
+          {
+            id: 'zoom',
+            uniform: 'uZoom',
+            type: 'number',
+            label: 'zoom',
+            default: 0,
+            min: -0.02,
+            max: 0.02,
+            step: 0.0001,
+          },
+          {
+            id: 'centerZoom',
+            type: 'boolean',
+            label: 'center zoom',
+            default: false,
+          },
+        ],
+      },
+    ],
   },
   blurredRipple: {
     label: 'Blurred Ripple',
     passes: [
-      { type: 'shader', fragment: gaussianBlurFrag },
-      { type: 'shader', fragment: rippleFadeFrag },
+      {
+        type: 'shader',
+        fragment: gaussianBlurFrag,
+        params: [
+          {
+            id: 'blurRadius',
+            uniform: 'uRadius',
+            type: 'number',
+            label: 'blur radius',
+            default: 1,
+            min: 0,
+            max: 10,
+            step: 1,
+          },
+        ],
+      },
+      {
+        type: 'shader',
+        fragment: rippleFadeFrag,
+        params: [
+          {
+            id: 'speed',
+            uniform: 'uSpeed',
+            type: 'number',
+            label: 'speed',
+            default: 0.05,
+            min: 0,
+            max: 0.3,
+            step: 0.001,
+          },
+          {
+            id: 'displacement',
+            uniform: 'uDisplacement',
+            type: 'number',
+            label: 'displacement',
+            default: 0.0015,
+            min: 0,
+            max: 0.003,
+            step: 0.0001,
+          },
+          {
+            id: 'detail',
+            uniform: 'uDetail',
+            type: 'number',
+            label: 'detail',
+            default: 2,
+            min: 0.1,
+            max: 5,
+            step: 0.01,
+          },
+          {
+            id: 'zoom',
+            uniform: 'uZoom',
+            type: 'number',
+            label: 'zoom',
+            default: 0,
+            min: -0.02,
+            max: 0.02,
+            step: 0.0001,
+          },
+          {
+            id: 'centerZoom',
+            type: 'boolean',
+            label: 'center zoom',
+            default: false,
+          },
+        ],
+      },
     ],
   },
-} as const
+} as const satisfies Record<string, { label: string; passes: readonly PassDescriptor[] }>
 
 export type EffectName = keyof typeof effectIndex
 export type EffectPass = PassDescriptor
+
+export type EffectParamDef = PassParamDef & { passIndex: number }
+
+export function getEffectParamDefs(effect: EffectName): EffectParamDef[] {
+  const { passes } = effectIndex[effect]
+  const result: EffectParamDef[] = []
+  passes.forEach((p, idx) => {
+    const pass = p as PassDescriptor
+    pass.params?.forEach((param: PassParamDef) => {
+      result.push({ ...param, passIndex: idx })
+    })
+  })
+  return result
+}


### PR DESCRIPTION
## Summary
- define `PassParamDef` and `getEffectParamDefs`
- list effect params inside each pass descriptor
- auto-build passParams in `DraggableForeground`
- dynamically generate effect parameter sliders in `DemoControls`
- document progress

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872bfb62f708332bed5f472662206d9