### PR TITLE
Fix mobile viewport scrolling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,8 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **69** – Refactored pass model to declare effect parameters per pass and auto-generate Tweakpane controls. Removed blur special-casing. Lint warns; build succeeds.
 - **70** – Introduced pass registry and reused ripple fade pass for blurred ripple effect. Lint warns; build passes.
 
+- **71** – Fixed mobile Safari viewport scroll by using `100dvh` height and `touch-action:none` on the canvas container. Updated meta viewport, added overflow locks, and disabled page scrolling. Lint warns; build succeeds.
+
 ## Next Steps
 
 - Implement more multi-pass effects using the new pipeline.

--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <title>feedbackground</title>
   </head>
   <body class="m-0 p-0">

--- a/src/App.css
+++ b/src/App.css
@@ -4,3 +4,9 @@ body,
   height: 100%;
   margin: 0;
 }
+
+html,
+body {
+  overflow: hidden;
+  overscroll-behavior: none;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,8 +76,8 @@ export default function App() {
         setCenterZoom={setCenterZoom}
       />
       <div
-        className="w-screen h-screen overflow-hidden bg-cover bg-center"
-        style={style}
+        className="w-screen overflow-hidden bg-cover bg-center"
+        style={{ ...style, height: '100dvh', touchAction: 'none' }}
       >
         <CanvasStage
           shaderName={shaderName}

--- a/src/components/CanvasStage.tsx
+++ b/src/components/CanvasStage.tsx
@@ -36,7 +36,7 @@ export default function CanvasStage({
   onInteract,
 }: CanvasStageProps) {
   return (
-    <Canvas className="w-full h-full">
+    <Canvas className="w-full h-full" style={{ touchAction: 'none' }}>
       <Suspense fallback={null}>
         <ForegroundLayerDemo
           shaderName={shaderName}


### PR DESCRIPTION
## Summary
- add `viewport-fit=cover`
- lock html/body scrolling and overscroll
- size stage with `100dvh` and disable touch gestures

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872ce4f22388332935ff155e2b81aec