### PR TITLE
Refactor ensureTargets to callback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **70** – Introduced pass registry and reused ripple fade pass for blurred ripple effect. Lint warns; build passes.
 
 - **71** – Fixed mobile Safari viewport scroll by using `100dvh` height and `touch-action:none` on the canvas container. Updated meta viewport, added overflow locks, and disabled page scrolling. Lint warns; build succeeds.
+- **72** – Converted `ensureTargets` to `useCallback` and updated dependencies. Lint and build pass.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- refactor `ensureTargets` into a `useCallback`
- include the callback in dependent hooks
- document update in AGENTS log

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68751ca2d49c8332abbc6baedd97d817