### PR TITLE
Use typed wrappers for Tweakpane

### DIFF
--- a/src/utils/tweakpane.ts
+++ b/src/utils/tweakpane.ts
@@ -1,0 +1,47 @@
+import type { BladeApi, FolderApi, InputBindingApi } from 'tweakpane'
+import type { Pane } from 'tweakpane'
+
+/**
+ * Typed wrapper for `addFolder` to avoid `any` casts.
+ */
+export function addFolderTyped(
+  parent: Pane | FolderApi,
+  params: Record<string, unknown>,
+): FolderApi {
+  return (parent as unknown as { addFolder(p: Record<string, unknown>): FolderApi }).addFolder(
+    params,
+  )
+}
+
+/**
+ * Typed wrapper for `addBlade` to avoid `any` casts.
+ */
+export function addBladeTyped<Api extends BladeApi>(
+  parent: Pane | FolderApi,
+  params: Record<string, unknown>,
+): Api {
+  return (parent as unknown as { addBlade(p: Record<string, unknown>): BladeApi }).addBlade(
+    params,
+  ) as Api
+}
+
+/**
+ * Typed wrapper for `addBinding` to avoid `any` casts.
+ */
+export function addBindingTyped<T>(
+  parent: Pane | FolderApi,
+  object: { [k: string]: T },
+  key: string,
+  params?: Record<string, unknown>,
+): InputBindingApi<T> {
+  return (parent as unknown as {
+    addBinding(obj: { [k: string]: T }, key: string, p?: Record<string, unknown>): InputBindingApi<T>
+  }).addBinding(object, key, params)
+}
+
+/**
+ * Typed wrapper for `remove`.
+ */
+export function removeBladeTyped(parent: Pane | FolderApi, child: BladeApi): void {
+  return (parent as unknown as { remove(api: BladeApi): void }).remove(child)
+}


### PR DESCRIPTION
## Summary
- add typed wrapper utilities for Tweakpane
- refactor `DemoControls` to use new typed helpers
- remove `as any` casts and related ESLint comments

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68751cc29f048332a19cf5aa4d8602fa