### PR TITLE
Add DPR limit for feedback renders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **70** – Introduced pass registry and reused ripple fade pass for blurred ripple effect. Lint warns; build passes.
 
 - **71** – Fixed mobile Safari viewport scroll by using `100dvh` height and `touch-action:none` on the canvas container. Updated meta viewport, added overflow locks, and disabled page scrolling. Lint warns; build succeeds.
+- **72** – Added optional `maxDpr` limit to `useFeedbackFBO` and threaded prop through `CanvasStage`. Updated README. Lint and build pass.
 
 ## Next Steps
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ express while single-pass effects such as `[rippleFade]` behave as before.
 | **Interpolation**   | Configure `useFrameInterpolator` params | Linear sub-sampling         |
 | **Physics engine**  | Swap `react-spring`                     | `react-spring`              |
 | **Input methods**   | Extend for touch, gesture, gamepad      | Mouse/pointer               |
+| **Render scale**    | `maxDpr` prop on `CanvasStage`          | `window.devicePixelRatio`   |
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ export default function App() {
   const [detail, setDetail] = useState(2)
   const [zoom, setZoom] = useState(0)
   const [centerZoom, setCenterZoom] = useState(false)
+  const maxDpr = 2
   const style =
     bgName === 'wildflowers'
       ? { backgroundImage: `url(${wildflowersUrl})` }
@@ -91,9 +92,10 @@ export default function App() {
           displacement={displacement}
           detail={detail}
           zoom={zoom}
-          centerZoom={centerZoom}
-          onInteract={() => setOverviewHidden(true)}
-        />
+        centerZoom={centerZoom}
+        maxDpr={maxDpr}
+        onInteract={() => setOverviewHidden(true)}
+      />
       </div>
     </>
   )

--- a/src/components/CanvasStage.tsx
+++ b/src/components/CanvasStage.tsx
@@ -17,6 +17,7 @@ export type CanvasStageProps = {
   detail: number
   zoom: number
   centerZoom: boolean
+  maxDpr?: number
   onInteract: () => void
 }
 
@@ -33,6 +34,7 @@ export default function CanvasStage({
   detail,
   zoom,
   centerZoom,
+  maxDpr,
   onInteract,
 }: CanvasStageProps) {
   return (
@@ -51,6 +53,7 @@ export default function CanvasStage({
           detail={detail}
           zoom={zoom}
           centerZoom={centerZoom}
+          maxDpr={maxDpr}
           onInteract={onInteract}
         />
       </Suspense>

--- a/src/components/DraggableForeground.tsx
+++ b/src/components/DraggableForeground.tsx
@@ -22,6 +22,7 @@ export type DraggableForegroundProps = {
   detail: number
   zoom: number
   centerZoom: boolean
+  maxDpr?: number
   onGrab?: () => void
 }
 
@@ -37,6 +38,7 @@ export default function DraggableForeground({
   detail,
   zoom,
   centerZoom,
+  maxDpr,
   onGrab,
 }: DraggableForegroundProps) {
   const dragRef = useRef<THREE.Group | null>(null)
@@ -75,7 +77,8 @@ export default function DraggableForeground({
     dragRef,
     passParams,
     centerZoom,
-    paintWhileStill
+    paintWhileStill,
+    maxDpr
   )
 
   return (

--- a/src/components/ForegroundLayerDemo.tsx
+++ b/src/components/ForegroundLayerDemo.tsx
@@ -22,6 +22,7 @@ export type ForegroundLayerDemoProps = {
   detail: number
   zoom: number
   centerZoom: boolean
+  maxDpr?: number
   onInteract: () => void
 }
 
@@ -38,6 +39,7 @@ export default function ForegroundLayerDemo({
   detail,
   zoom,
   centerZoom,
+  maxDpr,
   onInteract,
 }: ForegroundLayerDemoProps) {
   const svgUrl = useSvgUrl()
@@ -61,6 +63,7 @@ export default function ForegroundLayerDemo({
         detail={detail}
         zoom={zoom}
         centerZoom={centerZoom}
+        maxDpr={maxDpr}
         onGrab={onInteract}
       />
     </>

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -22,10 +22,11 @@ export default function useFeedbackFBO(
   externalRef?: MutableRefObject<THREE.Group | null>,
   passParams: Array<Record<string, number | boolean>> = [],
   centerZoom = false,
-  paintWhileStill = false
+  paintWhileStill = false,
+  maxDpr = Infinity
 ) {
   const { gl, size, camera, viewport } = useThree()
-  const dpr = gl.getPixelRatio()
+  const dpr = Math.min(gl.getPixelRatio(), maxDpr)
 
   const internalRef = useRef<THREE.Group | null>(null)
   const snapshotGroup = externalRef ?? internalRef
@@ -59,7 +60,7 @@ export default function useFeedbackFBO(
   }[]>(passes.map(() => createTarget()))
 
   function ensureTargets() {
-    const ratio = gl.getPixelRatio()
+    const ratio = Math.min(gl.getPixelRatio(), maxDpr)
     while (passTargets.current.length < passes.length) {
       passTargets.current.push(createTarget())
     }
@@ -142,7 +143,7 @@ export default function useFeedbackFBO(
   }, [sessionId, passData])
 
   useEffect(() => {
-    const ratio = gl.getPixelRatio()
+    const ratio = Math.min(gl.getPixelRatio(), maxDpr)
     snapshotRT.current.setSize(size.width * ratio, size.height * ratio)
     passTargets.current.forEach((t) => {
       t.read.setSize(size.width * ratio, size.height * ratio)


### PR DESCRIPTION
## Summary
- add `maxDpr` option to `useFeedbackFBO`
- thread `maxDpr` through `CanvasStage` and related components
- default to 2x DPR in `App`
- mention render-scale option in documentation
- log progress

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68751cd6f81083328932498445b48b1d