### PR TITLE
Disable feedback depth buffers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 
 - **72** – Removed `console.log` debug statement from `TextMesh`. Lint warns on hooks; build succeeds.
 - **72** – Added cleanup for shader materials and geometries in `useFeedbackFBO` when passes change. Lint and build pass.
+- **73** – Disabled depth buffers in feedback render targets to reduce memory usage. Lint and build pass.
 
 ## Next Steps
 
@@ -113,3 +114,4 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - Investigate "unsupported GSUB table LookupType 6" console warning from troika text.
 - Audit for stray debugging logs and remove them from production code.
 - Verify GPU resources are released when switching effects.
+- Confirm memory savings from disabling FBO depth buffers.

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -39,6 +39,7 @@ export default function useFeedbackFBO(
   const snapshotRT = useRef(
     new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr, {
       type: THREE.HalfFloatType,
+      depthBuffer: false,
     })
   )
 
@@ -46,9 +47,11 @@ export default function useFeedbackFBO(
     return {
       read: new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr, {
         type: THREE.HalfFloatType,
+        depthBuffer: false,
       }),
       write: new THREE.WebGLRenderTarget(size.width * dpr, size.height * dpr, {
         type: THREE.HalfFloatType,
+        depthBuffer: false,
       }),
     }
   }, [size, dpr])


### PR DESCRIPTION
## Summary
- disable depth buffer for all feedback render targets
- log update for depth-buffer change
- note memory savings in Next Steps

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68752c409b4c8332a4cfa1004a44c7b4