### PR TITLE
Fix ascii decay freeze

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **78** – Fixed ASCII grid orientation and reset snapshot state when idle to prevent frozen output. Lint and build pass.
 - **79** – Flipped shader Y axis and cleared the ASCII pass buffer each frame to keep text upright and prevent stuck frames. Lint and build pass.
 - **80** – Corrected ASCII pass orientation and rotated glyphs 180° so they display upright. Lint and build pass.
+- **81** – Cleared render targets when resized or created to prevent ASCII decay freeze after interactions. Lint and build pass.
 
 ## Next Steps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **82** – Multiplied ASCII glyph alpha by luminance so trails fade smoothly. Lint and build pass.
 - **83** – Fixed feedback output freeze by updating the displayed texture each frame and refactoring `FeedbackPlane` to track a ref. Lint and build pass.
 - **84** – Updated output texture assignment inside `useFeedbackFBO`'s render loop and ensured `FeedbackPlane` only updates its material map when the texture ref changes.
+- **85** – Added decay-aware history sampling in the ASCII luminance pass so trails persist after interactions. Lint and build pass.
 
 ## Next Steps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **81** – Cleared render targets when resized or created to prevent ASCII decay freeze after interactions. Lint and build pass.
 - **82** – Multiplied ASCII glyph alpha by luminance so trails fade smoothly. Lint and build pass.
 - **83** – Fixed feedback output freeze by updating the displayed texture each frame and refactoring `FeedbackPlane` to track a ref. Lint and build pass.
+- **84** – Updated output texture assignment inside `useFeedbackFBO`'s render loop and ensured `FeedbackPlane` only updates its material map when the texture ref changes.
 
 ## Next Steps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,10 +109,12 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **80** – Corrected ASCII pass orientation and rotated glyphs 180° so they display upright. Lint and build pass.
 - **81** – Cleared render targets when resized or created to prevent ASCII decay freeze after interactions. Lint and build pass.
 - **82** – Multiplied ASCII glyph alpha by luminance so trails fade smoothly. Lint and build pass.
+- **83** – Fixed feedback output freeze by updating the displayed texture each frame and refactoring `FeedbackPlane` to track a ref. Lint and build pass.
 
 ## Next Steps
 
 - Implement more multi-pass effects using the new pipeline.
+- Polish ASCII decay effect and expose character grid options.
 - Tune random paint and ripple fade blending for performance and visual quality.
 - Profile high-DPR rendering performance and optimize FBO sizing.
 - Expose additional shader uniforms via Tweakpane for experimentation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ This file tracks Codex progress and upcoming tasks. Keep it chronological and ap
 - **79** – Flipped shader Y axis and cleared the ASCII pass buffer each frame to keep text upright and prevent stuck frames. Lint and build pass.
 - **80** – Corrected ASCII pass orientation and rotated glyphs 180° so they display upright. Lint and build pass.
 - **81** – Cleared render targets when resized or created to prevent ASCII decay freeze after interactions. Lint and build pass.
+- **82** – Multiplied ASCII glyph alpha by luminance so trails fade smoothly. Lint and build pass.
 
 ## Next Steps
 

--- a/src/components/FeedbackPlane.tsx
+++ b/src/components/FeedbackPlane.tsx
@@ -8,7 +8,10 @@ export default function FeedbackPlane({ texture }: Props) {
   const { viewport } = useThree()
   const matRef = useRef<THREE.MeshBasicMaterial>(null)
   useFrame(() => {
-    if (matRef.current) matRef.current.map = texture.current
+    if (matRef.current && matRef.current.map !== texture.current) {
+      matRef.current.map = texture.current
+      matRef.current.needsUpdate = true
+    }
   })
   return (
     <mesh scale={[viewport.width, viewport.height, 1]} position-z={0}>

--- a/src/components/FeedbackPlane.tsx
+++ b/src/components/FeedbackPlane.tsx
@@ -1,14 +1,19 @@
-import { useThree } from '@react-three/fiber'
+import { useThree, useFrame } from '@react-three/fiber'
+import { useRef } from 'react'
 import * as THREE from 'three'
 
-type Props = { texture: THREE.Texture }
+type Props = { texture: React.MutableRefObject<THREE.Texture> }
 
 export default function FeedbackPlane({ texture }: Props) {
   const { viewport } = useThree()
+  const matRef = useRef<THREE.MeshBasicMaterial>(null)
+  useFrame(() => {
+    if (matRef.current) matRef.current.map = texture.current
+  })
   return (
     <mesh scale={[viewport.width, viewport.height, 1]} position-z={0}>
       <planeGeometry args={[1, 1]} />
-      <meshBasicMaterial map={texture} transparent toneMapped={false} />
+      <meshBasicMaterial ref={matRef} transparent toneMapped={false} />
     </mesh>
   )
 }

--- a/src/effects/asciiLuminance.ts
+++ b/src/effects/asciiLuminance.ts
@@ -32,7 +32,7 @@ const fragmentShader = `
     local = vec2(1.0 - local.x, 1.0 - local.y);
     vec2 atlasUV = vec2((index + local.x) / uCharCount, local.y);
     vec4 glyph = texture2D(uAtlas, atlasUV);
-    gl_FragColor = vec4(0.0, 0.0, 0.0, glyph.a);
+    gl_FragColor = vec4(0.0, 0.0, 0.0, glyph.a * lum);
   }
 `
 

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -296,9 +296,18 @@ export default function useFeedbackFBO(
     })
   })
 
-  const outputTex = passes.length
-    ? passTargets.current[passes.length - 1].read.texture
-    : snapshotRT.current.texture
+  const outputTex = useRef<THREE.Texture>(
+    passes.length
+      ? passTargets.current[passes.length - 1].read.texture
+      : snapshotRT.current.texture
+  )
+
+  useFrame(() => {
+    outputTex.current =
+      passes.length > 0
+        ? passTargets.current[passes.length - 1].read.texture
+        : snapshotRT.current.texture
+  })
 
   return { snapshotRef: snapshotGroup, texture: outputTex }
 }

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -73,6 +73,13 @@ export default function useFeedbackFBO(
     passTargets.current.forEach((t) => {
       t.read.setSize(size.width * ratio, size.height * ratio)
       t.write.setSize(size.width * ratio, size.height * ratio)
+      gl.setRenderTarget(t.read)
+      gl.setClearColor(0x000000, 0)
+      gl.clear(true, true, true)
+      gl.setRenderTarget(t.write)
+      gl.setClearColor(0x000000, 0)
+      gl.clear(true, true, true)
+      gl.setRenderTarget(null)
     })
   }, [gl, size, passes, createTarget])
 

--- a/src/hooks/useFeedbackFBO.ts
+++ b/src/hooks/useFeedbackFBO.ts
@@ -294,6 +294,11 @@ export default function useFeedbackFBO(
       ]
       prevTexture = passTargets.current[idx].read.texture
     })
+
+    outputTex.current =
+      passes.length > 0
+        ? passTargets.current[passes.length - 1].read.texture
+        : snapshotRT.current.texture
   })
 
   const outputTex = useRef<THREE.Texture>(
@@ -302,12 +307,7 @@ export default function useFeedbackFBO(
       : snapshotRT.current.texture
   )
 
-  useFrame(() => {
-    outputTex.current =
-      passes.length > 0
-        ? passTargets.current[passes.length - 1].read.texture
-        : snapshotRT.current.texture
-  })
+
 
   return { snapshotRef: snapshotGroup, texture: outputTex }
 }


### PR DESCRIPTION
## Summary
- clear render targets when sizes or passes change to avoid stale textures

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877a4274ee88332924e768dfdad7b22